### PR TITLE
cockroach-prod: start a cluster on cloud.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.a
 *.so
 
+# Binaries
+cockroach-prod
+
 # Folders
 _obj
 _test

--- a/base/context.go
+++ b/base/context.go
@@ -1,0 +1,53 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package base
+
+// Base context defaults.
+const (
+	defaultCerts  = "certs"
+	defaultDryRun = true
+	defaultPort   = 8080
+	defaultRegion = "aws:us-east-1"
+)
+
+// Context is the base context object.
+type Context struct {
+	// Certificates directory.
+	Certs string
+	// DryRun mode.
+	DryRun bool
+	// Port for cockroach nodes to listen on.
+	Port int64
+	// Region to run in.
+	Region string
+}
+
+// NewContext returns a context with initialized values.
+func NewContext() *Context {
+	ctx := &Context{}
+	ctx.InitDefaults()
+	return ctx
+}
+
+// InitDefaults sets up the default values for a context.
+func (ctx *Context) InitDefaults() {
+	ctx.Certs = defaultCerts
+	ctx.DryRun = defaultDryRun
+	ctx.Port = defaultPort
+	ctx.Region = defaultRegion
+}

--- a/base/context.go
+++ b/base/context.go
@@ -20,7 +20,6 @@ package base
 // Base context defaults.
 const (
 	defaultCerts  = "certs"
-	defaultDryRun = true
 	defaultPort   = 8080
 	defaultRegion = "aws:us-east-1"
 )
@@ -29,8 +28,6 @@ const (
 type Context struct {
 	// Certificates directory.
 	Certs string
-	// DryRun mode.
-	DryRun bool
 	// Port for cockroach nodes to listen on.
 	Port int64
 	// Region to run in.
@@ -47,7 +44,6 @@ func NewContext() *Context {
 // InitDefaults sets up the default values for a context.
 func (ctx *Context) InitDefaults() {
 	ctx.Certs = defaultCerts
-	ctx.DryRun = defaultDryRun
 	ctx.Port = defaultPort
 	ctx.Region = defaultRegion
 }

--- a/cli/add_nodes.go
+++ b/cli/add_nodes.go
@@ -32,7 +32,7 @@ import (
 
 var addNodesCmd = &commander.Command{
 	UsageLine: "add-nodes N",
-	Short:     "add new nodes\n",
+	Short:     "add new nodes",
 	Long: `
 Add N new nodes to an existing cluster
 `,

--- a/cli/add_nodes.go
+++ b/cli/add_nodes.go
@@ -1,0 +1,120 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+// The AWS library needs existing credentials.
+// See "Configuring Credentials" at: https://github.com/awslabs/aws-sdk-go
+package cli
+
+import (
+	"flag"
+	"strconv"
+
+	"code.google.com/p/go-commander"
+
+	"github.com/cockroachdb/cockroach-prod/docker"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+var addNodesCmd = &commander.Command{
+	UsageLine: "add-nodes N",
+	Short:     "add new nodes\n",
+	Long: `
+Add N new nodes to an existing cluster
+`,
+	Run:  runAddNodes,
+	Flag: *flag.CommandLine,
+}
+
+func runAddNodes(cmd *commander.Command, args []string) {
+	if len(args) != 1 {
+		cmd.Usage()
+		return
+	}
+	numNodes, err := strconv.Atoi(args[0])
+	if err != nil || numNodes < 1 {
+		log.Errorf("argument %s must be an integer > 0", args)
+		return
+	}
+
+	for i := 1; i <= numNodes; i++ {
+		log.Infof("adding node %d of %d", i, numNodes)
+		err := AddOneNode()
+		if err != nil {
+			log.Errorf("problem adding node: %v", err)
+			return
+		}
+	}
+}
+
+func AddOneNode() error {
+	driver, err := NewDriver(Context)
+	if err != nil {
+		return util.Errorf("could not create driver: %v", err)
+	}
+
+	err = driver.Init()
+	if err != nil {
+		return util.Errorf("failed to initialized driver: %v", err)
+	}
+
+	nodes, err := docker.ListCockroachNodes()
+	if err != nil {
+		return util.Errorf("failed to get list of existing cockroach nodes: %v", err)
+	}
+	if len(nodes) == 0 {
+		return util.Errorf("no existing cockroach nodes detected, this means there is probably no existing cluster")
+	}
+
+	largestIndex, err := docker.GetLargestNodeIndex(nodes)
+	if err != nil {
+		return util.Errorf("problem parsing existing node list: %v", err)
+	}
+
+	nodeName := docker.MakeNodeName(largestIndex + 1)
+
+	// Create node.
+	err = docker.CreateMachine(driver, nodeName)
+	if err != nil {
+		return util.Errorf("could not create machine %s: %v", nodeName, err)
+	}
+
+	// Lookup node info.
+	nodeConfig, err := docker.GetMachineConfig(nodeName)
+	if err != nil {
+		return util.Errorf("could not get node config for %s: %v", nodeName, err)
+	}
+
+	// Do "new node" logic.
+	err = driver.AddNode(nodeName, nodeConfig)
+	if err != nil {
+		return util.Errorf("could not run AddNode steps for %s: %v", nodeName, err)
+	}
+
+	// Initialize cockroach node.
+	nodeDriverSettings, err := driver.GetNodeSettings(nodeName, nodeConfig)
+	if err != nil {
+		return util.Errorf("could not determine node settings for %s: %v", nodeName, err)
+	}
+
+	// Start the cockroach node.
+	err = docker.RunDockerStart(Context, nodeName, nodeDriverSettings)
+	if err != nil {
+		return util.Errorf("could not initialize first cockroach node %s: %v", nodeName, err)
+	}
+	return nil
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -89,6 +89,7 @@ var allCmds = &commander.Commander{
 		// Cluster setup.
 		initCmd,
 		addNodesCmd,
+		stopCmd,
 
 		// Status commands.
 		statusCmd,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,104 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cockroachdb/cockroach-prod/base"
+	"github.com/cockroachdb/cockroach-prod/drivers"
+	"github.com/cockroachdb/cockroach-prod/drivers/amazon"
+	"github.com/cockroachdb/cockroach/util"
+
+	commander "code.google.com/p/go-commander"
+)
+
+var Context = base.NewContext()
+
+var listParamsCmd = &commander.Command{
+	UsageLine: "listparams",
+	Short:     "list all available parameters and their default values",
+	Long: `
+List all available parameters and their default values.
+Note that parameter parsing stops after the first non-
+option after the command name. Hence, the options need
+to precede any additional arguments,
+
+  cockroach-prod <command> [options] [arguments].`,
+	Run: func(cmd *commander.Command, args []string) {
+		flag.CommandLine.PrintDefaults()
+	},
+}
+
+// NewDriver creates a new driver based on the passed-in Context.
+func NewDriver(context *base.Context) (drivers.Driver, error) {
+	tokens := strings.SplitN(context.Region, ":", 2)
+	if len(tokens) != 2 {
+		return nil, util.Errorf("invalid region syntax, expected <driver>:<region name>, got: %q", context.Region)
+	}
+
+	driver := tokens[0]
+	region := tokens[1]
+	if driver == "aws" {
+		return amazon.NewDriver(context, region), nil
+	}
+	return nil, util.Errorf("unknown driver: %s", driver)
+}
+
+var versionCmd = &commander.Command{
+	UsageLine: "version",
+	Short:     "output version information",
+	Long: `
+Output build version information.
+`,
+	Run: func(cmd *commander.Command, args []string) {
+		info := util.GetBuildInfo()
+		w := &tabwriter.Writer{}
+		w.Init(os.Stdout, 2, 1, 2, ' ', 0)
+		fmt.Fprintf(w, "Build Vers:  %s\n", info.Vers)
+		fmt.Fprintf(w, "Build Tag:   %s\n", info.Tag)
+		fmt.Fprintf(w, "Build Time:  %s\n", info.Time)
+		fmt.Fprintf(w, "Build Deps:\n\t%s\n",
+			strings.Replace(strings.Replace(info.Deps, " ", "\n\t", -1), ":", "\t", -1))
+		w.Flush()
+	},
+}
+
+var allCmds = &commander.Commander{
+	Name: "cockroach-prod",
+	Commands: []*commander.Command{
+		// Cluster setup.
+		initCmd,
+
+		// Status commands.
+		statusCmd,
+
+		// Misc commands.
+		listParamsCmd,
+		versionCmd,
+	},
+}
+
+// Run ...
+func Run(args []string) error {
+	return allCmds.Run(args)
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -88,6 +88,7 @@ var allCmds = &commander.Commander{
 	Commands: []*commander.Command{
 		// Cluster setup.
 		initCmd,
+		addNodesCmd,
 
 		// Status commands.
 		statusCmd,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -1,0 +1,42 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package cli
+
+import (
+	"flag"
+
+	"github.com/cockroachdb/cockroach-prod/base"
+)
+
+// initFlags sets the base/context values to flag values.
+func initFlags(ctx *base.Context) {
+	flag.StringVar(&ctx.Certs, "certs", ctx.Certs, "certificates directory. Generated CA and node "+
+		"certs and keys are stored there.")
+
+	flag.BoolVar(&ctx.DryRun, "dry-run", ctx.DryRun, "print out mutating actions, don't perform them.")
+
+	flag.Int64Var(&ctx.Port, "port", ctx.Port, "cockroach node and load balancer port.")
+
+	// TODO(marc): this may take a "cloud platform" attribute (eg: aws:<region> or gce:<region>).
+	// We will also need multi-region commands (eg: status, adding new region, etc...)
+	flag.StringVar(&ctx.Region, "region", ctx.Region, "region to run in.")
+}
+
+func init() {
+	initFlags(Context)
+}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -28,8 +28,6 @@ func initFlags(ctx *base.Context) {
 	flag.StringVar(&ctx.Certs, "certs", ctx.Certs, "certificates directory. Generated CA and node "+
 		"certs and keys are stored there.")
 
-	flag.BoolVar(&ctx.DryRun, "dry-run", ctx.DryRun, "print out mutating actions, don't perform them.")
-
 	flag.Int64Var(&ctx.Port, "port", ctx.Port, "cockroach node and load balancer port.")
 
 	// TODO(marc): this may take a "cloud platform" attribute (eg: aws:<region> or gce:<region>).

--- a/cli/init.go
+++ b/cli/init.go
@@ -30,7 +30,7 @@ import (
 
 var initCmd = &commander.Command{
 	UsageLine: "init",
-	Short:     "initialize a cockroach cluster\n",
+	Short:     "initialize a cockroach cluster",
 	Long: `
 Initialize a cockroach cluster.
 `,
@@ -100,6 +100,7 @@ func runInit(cmd *commander.Command, args []string) {
 	err = docker.RunDockerInit(Context, nodeName, nodeDriverSettings)
 	if err != nil {
 		log.Errorf("could not initialize first cockroach node %s: %v", nodeName, err)
+		return
 	}
 
 	// Start the cockroach node.

--- a/cli/init.go
+++ b/cli/init.go
@@ -1,0 +1,110 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+// The AWS library needs existing credentials.
+// See "Configuring Credentials" at: https://github.com/awslabs/aws-sdk-go
+package cli
+
+import (
+	"flag"
+
+	"code.google.com/p/go-commander"
+
+	"github.com/cockroachdb/cockroach-prod/docker"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+var initCmd = &commander.Command{
+	UsageLine: "init",
+	Short:     "initialize a cockroach cluster\n",
+	Long: `
+Initialize a cockroach cluster.
+`,
+	Run:  runInit,
+	Flag: *flag.CommandLine,
+}
+
+func runInit(cmd *commander.Command, args []string) {
+	driver, err := NewDriver(Context)
+	if err != nil {
+		log.Errorf("could not create driver: %v", err)
+		return
+	}
+
+	err = driver.Init()
+	if err != nil {
+		log.Errorf("failed to initialized driver: %v", err)
+		return
+	}
+
+	nodes, err := docker.ListCockroachNodes()
+	if err != nil {
+		log.Errorf("failed to get list of existing cockroach nodes: %v", err)
+		return
+	}
+	if len(nodes) != 0 {
+		log.Errorf("init called but docker-machine has %d existing cockroach nodes: %v", len(nodes), nodes)
+		return
+	}
+
+	nodeName := docker.MakeNodeName(0)
+	// Create first node.
+	err = docker.CreateMachine(driver, nodeName)
+	if err != nil {
+		log.Errorf("could not create machine %s: %v", nodeName, err)
+		return
+	}
+
+	// Lookup node info.
+	nodeConfig, err := docker.GetMachineConfig(nodeName)
+	if err != nil {
+		log.Errorf("could not get node config for %s: %v", nodeName, err)
+		return
+	}
+
+	// Run driver steps after first-node creation.
+	err = driver.ProcessFirstNode(nodeName, nodeConfig)
+	if err != nil {
+		log.Errorf("could not run ProcessFirstNode steps for %s: %v", nodeName, err)
+		return
+	}
+
+	// Do "new node" logic.
+	err = driver.AddNode(nodeName, nodeConfig)
+	if err != nil {
+		log.Errorf("could not run AddNode steps for %s: %v", nodeName, err)
+		return
+	}
+
+	// Initialize cockroach node.
+	nodeDriverSettings, err := driver.GetNodeSettings(nodeName, nodeConfig)
+	if err != nil {
+		log.Errorf("could not determine node settings for %s: %v", nodeName, err)
+		return
+	}
+
+	err = docker.RunDockerInit(Context, nodeName, nodeDriverSettings)
+	if err != nil {
+		log.Errorf("could not initialize first cockroach node %s: %v", nodeName, err)
+	}
+
+	// Start the cockroach node.
+	err = docker.RunDockerStart(Context, nodeName, nodeDriverSettings)
+	if err != nil {
+		log.Errorf("could not initialize first cockroach node %s: %v", nodeName, err)
+	}
+}

--- a/cli/init.go
+++ b/cli/init.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 
 	"code.google.com/p/go-commander"
-
 	"github.com/cockroachdb/cockroach-prod/docker"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -32,7 +31,7 @@ var initCmd = &commander.Command{
 	UsageLine: "init",
 	Short:     "initialize a cockroach cluster",
 	Long: `
-Initialize a cockroach cluster.
+Initialize a cockroach cluster. This initializes and starts the first node.
 `,
 	Run:  runInit,
 	Flag: *flag.CommandLine,

--- a/cli/status.go
+++ b/cli/status.go
@@ -1,0 +1,83 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+// The AWS library needs existing credentials.
+// See "Configuring Credentials" at: https://github.com/awslabs/aws-sdk-go
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"code.google.com/p/go-commander"
+
+	"github.com/cockroachdb/cockroach-prod/docker"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/ghemawat/stream"
+)
+
+var statusCmd = &commander.Command{
+	UsageLine: "status",
+	Short:     "show status\n",
+	Long: `
+Show status.
+`,
+	Run:  runStatus,
+	Flag: *flag.CommandLine,
+}
+
+func runStatus(cmd *commander.Command, args []string) {
+	// Check dependencies first.
+	if err := docker.CheckDockerMachine(); err != nil {
+		log.Errorf("docker-machine is not properly installed: %v", err)
+		return
+	}
+	log.Info("docker-machine binary found")
+
+	if err := docker.CheckDocker(); err != nil {
+		log.Errorf("docker is not properly installed: %v", err)
+		return
+	}
+	log.Info("docker binary found")
+
+	// Print docker-machine status.
+	fmt.Println("######## docker-machine ########")
+	err := stream.Run(
+		stream.Command("docker-machine", "ls"),
+		stream.WriteLines(os.Stdout),
+	)
+	if err != nil {
+		log.Error(err)
+	}
+
+	// Get driver-specific status.
+	driver, err := NewDriver(Context)
+	if err != nil {
+		log.Errorf("could not create driver: %v", err)
+		return
+	}
+
+	err = driver.Init()
+	if err != nil {
+		log.Errorf("failed to initialized driver: %v", err)
+		return
+	}
+
+	fmt.Printf("\n######### %s ########\n", driver.DockerMachineDriver())
+	driver.PrintStatus()
+}

--- a/cli/status.go
+++ b/cli/status.go
@@ -23,12 +23,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"code.google.com/p/go-commander"
 
 	"github.com/cockroachdb/cockroach-prod/docker"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/ghemawat/stream"
 )
 
 var statusCmd = &commander.Command{
@@ -57,10 +57,11 @@ func runStatus(cmd *commander.Command, args []string) {
 
 	// Print docker-machine status.
 	fmt.Println("######## docker-machine ########")
-	err := stream.Run(
-		stream.Command("docker-machine", "ls"),
-		stream.WriteLines(os.Stdout),
-	)
+	c := exec.Command("docker-machine", "ls")
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	err := c.Run()
+
 	if err != nil {
 		log.Error(err)
 	}

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -1,0 +1,70 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+// The AWS library needs existing credentials.
+// See "Configuring Credentials" at: https://github.com/awslabs/aws-sdk-go
+package cli
+
+import (
+	"flag"
+
+	"code.google.com/p/go-commander"
+
+	"github.com/cockroachdb/cockroach-prod/docker"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+var stopCmd = &commander.Command{
+	UsageLine: "stop",
+	Short:     "stop all nodes\n",
+	Long: `
+Stop all nodes.
+`,
+	Run:  runStop,
+	Flag: *flag.CommandLine,
+}
+
+func runStop(cmd *commander.Command, args []string) {
+	driver, err := NewDriver(Context)
+	if err != nil {
+		log.Errorf("could not create driver: %v", err)
+		return
+	}
+
+	err = driver.Init()
+	if err != nil {
+		log.Errorf("failed to initialized driver: %v", err)
+		return
+	}
+
+	nodes, err := docker.ListCockroachNodes()
+	if err != nil {
+		log.Errorf("failed to get list of existing cockroach nodes: %v", err)
+		return
+	}
+	if len(nodes) == 0 {
+		log.Errorf("no existing cockroach nodes detected, this means there is probably no existing cluster")
+		return
+	}
+
+	for _, node := range nodes {
+		err = docker.StopMachine(node)
+		if err != nil {
+			log.Errorf("could not stop machine %s: %v", node, err)
+		}
+	}
+}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -42,8 +42,8 @@ func CheckDocker() error {
 		return err
 	}
 	if !strings.HasPrefix(string(out), dockerVersionStringPrefix) {
-		return util.Errorf("bad output %v for docker -v, expected string prefix %q",
-			string(out), dockerVersionStringPrefix)
+		return util.Errorf("bad output %s for docker -v, expected string prefix %q",
+			out, dockerVersionStringPrefix)
 	}
 	return nil
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,0 +1,103 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package docker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/cockroachdb/cockroach-prod/base"
+	"github.com/cockroachdb/cockroach-prod/drivers"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/ghemawat/stream"
+)
+
+const (
+	dockerVersionStringPrefix = "Docker version "
+)
+
+// CheckDocker verifies that docker-machine is installed and runnable.
+func CheckDocker() error {
+	out, err := stream.Contents(stream.Command("docker", "-v"))
+	if err != nil {
+		return err
+	}
+	if out == nil || len(out) != 1 {
+		return util.Errorf("bad output %v for docker -v, expected string prefix %q",
+			out, dockerVersionStringPrefix)
+	}
+	if !strings.HasPrefix(out[0], dockerVersionStringPrefix) {
+		return util.Errorf("bad output %v for docker -v, expected string prefix %q",
+			out, dockerVersionStringPrefix)
+	}
+	return nil
+}
+
+// RunDockerInit initializes the first node.
+func RunDockerInit(context *base.Context, nodeName string, settings drivers.NodeSettings) error {
+	dockerArgs, err := GetDockerFlags(nodeName)
+	if err != nil {
+		return err
+	}
+	args := dockerArgs
+	args = append(args,
+		"run",
+		"--rm",
+		"-v", fmt.Sprintf("%s:/data", settings.DataDir()),
+		"cockroachdb/cockroach",
+		"init",
+		"-insecure",
+		"-stores", "ssd=/data",
+	)
+	log.Infof("running: docker %s", strings.Join(args, " "))
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// RunDockerStart starts the cockroach binary.
+func RunDockerStart(context *base.Context, nodeName string, settings drivers.NodeSettings) error {
+	dockerArgs, err := GetDockerFlags(nodeName)
+	if err != nil {
+		return err
+	}
+	args := dockerArgs
+	args = append(args,
+		"run",
+		"-d",
+		"--rm",
+		"-v", fmt.Sprintf("%s:/data", settings.DataDir()),
+		"-p", fmt.Sprintf("%d:%d", context.Port, context.Port),
+		"--net", "host",
+		"cockroachdb/cockroach",
+		"start",
+		"-insecure",
+		"-stores", "ssd=/data",
+		"-addr", fmt.Sprintf("%s:%d", settings.IPAddress(), context.Port),
+		"-gossip", fmt.Sprintf("%s:%d", settings.GossipAddress(), context.Port),
+	)
+	log.Infof("running: docker %s", strings.Join(args, " "))
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/docker/machine.go
+++ b/docker/machine.go
@@ -58,8 +58,8 @@ func CheckDockerMachine() error {
 		return err
 	}
 	if !strings.HasPrefix(string(out), dockerMachineVersionStringPrefix) {
-		return util.Errorf("bad output %v for docker-machine -v, expected string prefix %q",
-			string(out), dockerMachineVersionStringPrefix)
+		return util.Errorf("bad output %s for docker-machine -v, expected string prefix %q",
+			out, dockerMachineVersionStringPrefix)
 	}
 	return nil
 }
@@ -107,7 +107,7 @@ func GetLargestNodeIndex(nodes []string) (int, error) {
 }
 
 // GetMachineConfig gets the machine config from docker-machine.
-// It returns a generic interface.
+// It returns unmarshalled json.
 func GetMachineConfig(name string) (interface{}, error) {
 	contents, err := stream.Contents(stream.Command(dockerMachineBinary, "inspect", name))
 	if err != nil {

--- a/docker/machine.go
+++ b/docker/machine.go
@@ -156,3 +156,12 @@ func CreateMachine(driver drivers.Driver, name string) error {
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
+
+// StopMachine invokes docker-machine stop on the given machine name.
+func StopMachine(name string) error {
+	log.Infof("stopping docker machine %s", name)
+	cmd := exec.Command(dockerMachineBinary, "stop", name)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
+}

--- a/docker/machine.go
+++ b/docker/machine.go
@@ -1,0 +1,144 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package docker
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/cockroach-prod/drivers"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/ghemawat/stream"
+)
+
+const (
+	dockerMachineVersionStringPrefix = "docker-machine version "
+	dockerMachineBinary              = "docker-machine"
+	dockerMachineStoragePath         = "${HOME}/.docker/machine"
+	cockroachNodeName                = `cockroach-%d`
+)
+
+var (
+	cockroachNodeRegexp = regexp.MustCompile(`^cockroach-[0-9]+$`)
+)
+
+// MakeNodeName generates a cockroach node name for the given ID.
+func MakeNodeName(id int) string {
+	return fmt.Sprintf(cockroachNodeName, id)
+}
+
+// CheckDockerMachine verifies that docker-machine is installed and
+// runnable.
+func CheckDockerMachine() error {
+	out, err := stream.Contents(stream.Command(dockerMachineBinary, "-v"))
+	if err != nil {
+		return err
+	}
+	if out == nil || len(out) != 1 {
+		return util.Errorf("bad output %v for docker-machine -v, expected string prefix %q",
+			out, dockerMachineVersionStringPrefix)
+	}
+	if !strings.HasPrefix(out[0], dockerMachineVersionStringPrefix) {
+		return util.Errorf("bad output %v for docker-machine -v, expected string prefix %q",
+			out, dockerMachineVersionStringPrefix)
+	}
+	return nil
+}
+
+// ListMachines returns a list of machine names.
+func ListMachines() ([]string, error) {
+	return stream.Contents(stream.Command(dockerMachineBinary, "ls", "-q"))
+}
+
+// ListCockroachNodes returns a list of machines that are cockroach nodes.
+// We could use stream with grep, but let's minimize our dependencies.
+// docker-machine is also terrible at proper exit codes.
+func ListCockroachNodes() ([]string, error) {
+	machines, err := ListMachines()
+	if err != nil {
+		return nil, err
+	}
+	ret := []string{}
+	for _, mach := range machines {
+		if cockroachNodeRegexp.MatchString(mach) {
+			ret = append(ret, mach)
+		}
+	}
+	return ret, nil
+}
+
+// GetMachineConfig gets the machine config from docker-machine.
+// It returns a generic interface.
+func GetMachineConfig(name string) (interface{}, error) {
+	contents, err := stream.Contents(stream.Command(dockerMachineBinary, "inspect", name))
+	if err != nil {
+		return nil, err
+	}
+
+	var m interface{}
+	err = json.Unmarshal([]byte(strings.Join(contents, "\n")), &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// GetDockerFlags returns the list of flags we need to pass to docker to
+// talk to the given machine's docker daemon.
+// We expect a single line, but then split that line into individual flags.
+func GetDockerFlags(name string) ([]string, error) {
+	contents, err := stream.Contents(stream.Command(dockerMachineBinary, "config", name))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(contents) != 1 {
+		return nil, util.Errorf("expected a single output line, got: %v", contents)
+	}
+	return strings.Split(contents[0], " "), nil
+}
+
+// CreateMachine creates a new docker machine using the passed-in driver
+// and name.
+func CreateMachine(driver drivers.Driver, name string) error {
+	log.Infof("creating docker-machine %s", name)
+
+	args := []string{
+		"create",
+		"--driver", driver.DockerMachineDriver(),
+	}
+	args = append(args, driver.DockerMachineCreateArgs()...)
+	args = append(args, name)
+
+	log.Infof("running: %s %s", dockerMachineBinary, strings.Join(args, " "))
+	if driver.Context().DryRun {
+		log.Info("dry-run mode: not creating machine")
+		return nil
+	}
+
+	cmd := exec.Command(dockerMachineBinary, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/drivers/amazon/driver.go
+++ b/drivers/amazon/driver.go
@@ -1,0 +1,193 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package amazon
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach-prod/base"
+	"github.com/cockroachdb/cockroach-prod/drivers"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+const (
+	dockerMachineDriverName = "amazonec2"
+	amazonDataDir           = "/home/ubuntu/data"
+	cockroachProtocol       = "tcp"
+)
+
+// Amazon implements a driver for AWS.
+type Amazon struct {
+	context *base.Context
+	region  string
+
+	keyID string
+	key   string
+
+	vpcID string
+}
+
+type NodeInfo struct {
+	instanceID          string
+	securityGroupID     string
+	privateIPAddress    string
+	zone                string
+	loadBalancerAddress string
+}
+
+func (n *NodeInfo) DataDir() string {
+	return amazonDataDir
+}
+
+func (n *NodeInfo) IPAddress() string {
+	return n.privateIPAddress
+}
+
+func (n *NodeInfo) GossipAddress() string {
+	return n.loadBalancerAddress
+}
+
+// NewDriver returns an initialized Amazon driver.
+// TODO(marc): we should keep initialized services (eg: elb, ec2).
+func NewDriver(context *base.Context, region string) *Amazon {
+	return &Amazon{
+		context: context,
+		region:  region,
+	}
+}
+
+// Context returns the base context.
+func (a *Amazon) Context() *base.Context {
+	return a.context
+}
+
+// DockerMachineDriver returns the name of the docker-machine driver.
+func (a *Amazon) DockerMachineDriver() string {
+	return dockerMachineDriverName
+}
+
+// Init looks for AWS credentials.
+func (a *Amazon) Init() error {
+	var err error
+	a.keyID, a.key, err = LoadAWSCredentials()
+	if err != nil {
+		return util.Errorf("unable to load AWS credentials: %v", err)
+	}
+	log.Infof("loaded AWS key: %s", a.keyID)
+
+	// Find default VPC.
+	a.vpcID, err = FindDefaultVPC(a.region)
+	if err != nil {
+		return util.Errorf("could not find default VPC ID in region %s: %v", a.region, err)
+	}
+	log.Infof("found default VPC id: %s", a.vpcID)
+
+	return nil
+}
+
+// DockerMachineCreateArgs returns the list of driver-specific arguments
+// to pass to 'docker-machine create'
+// TODO(marc): there are many other flags, see 'docker-machine help create'
+func (a *Amazon) DockerMachineCreateArgs() []string {
+	return []string{
+		"--amazonec2-access-key", a.keyID,
+		"--amazonec2-secret-key", a.key,
+		"--amazonec2-region", a.region,
+		"--amazonec2-vpc-id", a.vpcID,
+	}
+}
+
+// PrintStatus prints the load balancer address to stdout.
+func (a *Amazon) PrintStatus() {
+	log.Infof("looking for load balancer")
+	elbDesc, err := FindCockroachELB(a.region)
+	if err != nil || elbDesc == nil {
+		log.Infof("could not find load balancer: %v", err)
+		return
+	}
+
+	fmt.Printf("Load balancer: %s\n", *elbDesc.DNSName)
+}
+
+// GetNodeSettings takes a node name and unmarshalled json config
+// and returns a filled NodeInfo.
+func (a *Amazon) GetNodeSettings(name string, config interface{}) (drivers.NodeSettings, error) {
+	settings, err := ParseDockerMachineConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	elbDesc, err := FindCockroachELB(a.region)
+	if err != nil || elbDesc == nil {
+		return nil, util.Errorf("could not find load balancer: %v", err)
+	}
+	settings.loadBalancerAddress = *elbDesc.DNSName
+	return settings, err
+}
+
+// ProcessFirstNode runs any steps needed after the first node was created.
+// This tweaks the security group to allow cockroach ports and creates
+// the load balancer.
+func (a *Amazon) ProcessFirstNode(name string, config interface{}) error {
+	nodeInfo, err := ParseDockerMachineConfig(config)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("adding security group rule for node: %+v", nodeInfo)
+	err = AddCockroachSecurityGroupIngress(a.region, a.context.Port, nodeInfo)
+	if err != nil {
+		return util.Errorf("failed to add security group rule for node %+v: %v", nodeInfo, err)
+	}
+
+	log.Infof("looking for load balancer")
+	elbDesc, err := FindCockroachELB(a.region)
+	if err != nil {
+		return util.Errorf("failed to lookup existing load balancer for node %+v: %v", nodeInfo, err)
+	}
+
+	if elbDesc != nil {
+		log.Info("found load balancer")
+		return nil
+	}
+
+	log.Infof("no existing load balancer, creating one")
+	err = CreateCockroachELB(a.region, a.context.Port, nodeInfo)
+	if err != nil {
+		return util.Errorf("failed to create load balancer for node %+v: %v", nodeInfo, err)
+	}
+	log.Info("created load balancer")
+	return nil
+}
+
+// AddNode runs any steps needed to add a node (any node, not just the first one).
+// This just adds the node to the load balancer.
+func (a *Amazon) AddNode(name string, config interface{}) error {
+	nodeInfo, err := ParseDockerMachineConfig(config)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("adding node %+v to load balancer", nodeInfo)
+	err = AddNodeToELB(a.region, nodeInfo)
+	if err != nil {
+		return util.Errorf("failed to add node %+v to load balancer: %v", nodeInfo, err)
+	}
+	return nil
+}

--- a/drivers/amazon/elb.go
+++ b/drivers/amazon/elb.go
@@ -1,0 +1,97 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package amazon
+
+import (
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/elb"
+	"github.com/cockroachdb/cockroach/util"
+)
+
+const (
+	cockroachELBName    = "cockroach-db"
+	awsELBNotFoundError = "LoadBalancerNotFound"
+)
+
+// FindCockroachELB looks for the cockroach ELB in the given region
+// and returns its description if found.
+// If not found, err=nil and description=nil.
+func FindCockroachELB(region string) (*elb.LoadBalancerDescription, error) {
+	elbService := elb.New(&aws.Config{Region: region})
+	elbs, err := elbService.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+		LoadBalancerNames: []*string{
+			aws.String(cockroachELBName),
+		},
+	})
+
+	if err != nil {
+		if awserr := aws.Error(err); awserr != nil && awserr.Code == awsELBNotFoundError {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if len(elbs.LoadBalancerDescriptions) == 0 {
+		return nil, nil
+	}
+	if len(elbs.LoadBalancerDescriptions) > 1 {
+		return nil, util.Errorf("found %d ELBs named %s", len(elbs.LoadBalancerDescriptions), cockroachELBName)
+	}
+
+	return elbs.LoadBalancerDescriptions[0], nil
+}
+
+// CreateCockroachELB creates a new load balancer in the given region.
+// It uses the nodeInfo and cockroachPort to fill in the request.
+// We cannot specify health check parameters at creation time, but AWS
+// uses the following defaults:
+// target: TCP:instance_port
+// timeout: 5s
+// interval: 30s
+// thresholds: unhealthy:2, heathy:10
+// TODO(marc): we should call ConfigureHealthCheck
+func CreateCockroachELB(region string, cockroachPort int64, info *NodeInfo) error {
+	elbService := elb.New(&aws.Config{Region: region})
+	_, err := elbService.CreateLoadBalancer(&elb.CreateLoadBalancerInput{
+		LoadBalancerName: aws.String(cockroachELBName),
+		SecurityGroups:   []*string{aws.String(info.securityGroupID)},
+		Listeners: []*elb.Listener{
+			{
+				InstancePort:     aws.Long(cockroachPort),
+				InstanceProtocol: aws.String(cockroachProtocol),
+				LoadBalancerPort: aws.Long(cockroachPort),
+				Protocol:         aws.String(cockroachProtocol),
+			},
+		},
+		AvailabilityZones: []*string{
+			aws.String(region + info.zone),
+		},
+	})
+	return err
+}
+
+// AddNodeToELB adds the specified node to the cockroach load balancer.
+// This can only succeed if the cockroach ELB exists.
+func AddNodeToELB(region string, info *NodeInfo) error {
+	elbService := elb.New(&aws.Config{Region: region})
+	_, err := elbService.RegisterInstancesWithLoadBalancer(&elb.RegisterInstancesWithLoadBalancerInput{
+		LoadBalancerName: aws.String(cockroachELBName),
+		Instances:        []*elb.Instance{{InstanceID: aws.String(info.instanceID)}},
+	})
+	return err
+}

--- a/drivers/amazon/security_group.go
+++ b/drivers/amazon/security_group.go
@@ -1,0 +1,53 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package amazon
+
+import (
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
+)
+
+const (
+	allIPAddresses                = "0.0.0.0/0"
+	awsSecurityRuleDuplicateError = "InvalidPermission.Duplicate"
+)
+
+// AddCockroachSecurityGroupIngress takes in a nodeInfo and
+// adds the cockroach port ingress rules to the security group.
+// The To and From ports are set to 'cockroachPort'.
+// Duplicates are technically errors according to the AWS API, but we check for
+// the duplicate error code and return ok.
+func AddCockroachSecurityGroupIngress(region string, cockroachPort int64, node *NodeInfo) error {
+	ec2Service := ec2.New(&aws.Config{Region: region})
+
+	_, err := ec2Service.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		CIDRIP:     aws.String(allIPAddresses),
+		FromPort:   aws.Long(cockroachPort),
+		ToPort:     aws.Long(cockroachPort),
+		IPProtocol: aws.String(cockroachProtocol),
+		GroupID:    aws.String(node.securityGroupID),
+	})
+
+	if err != nil {
+		if awserr := aws.Error(err); awserr != nil && awserr.Code == awsSecurityRuleDuplicateError {
+			return nil
+		}
+	}
+
+	return err
+}

--- a/drivers/amazon/utils.go
+++ b/drivers/amazon/utils.go
@@ -1,0 +1,104 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package amazon
+
+import (
+	"io/ioutil"
+	"os"
+	"regexp"
+
+	"github.com/cockroachdb/cockroach/util"
+)
+
+const (
+	credentialsPath = "${HOME}/.aws/credentials"
+)
+
+var (
+	keyIDRegexp = regexp.MustCompile(`\naws_access_key_id = ([^\n]+)\n`)
+	keyRegexp   = regexp.MustCompile(`\naws_secret_access_key = ([^\n]+)\n`)
+)
+
+// LoadAWSCredentials looks for the .aws/credentials file, parses it, and returns the
+// key-id and secret-key.
+func LoadAWSCredentials() (string, string, error) {
+	credPath := os.ExpandEnv(credentialsPath)
+	contents, err := ioutil.ReadFile(credPath)
+	if err != nil {
+		return "", "", err
+	}
+
+	match := keyIDRegexp.FindSubmatch(contents)
+	if match == nil || len(match) != 2 {
+		return "", "", util.Errorf("could not extract aws_access_key_id from %s", credPath)
+	}
+	keyID := match[1]
+
+	match = keyRegexp.FindSubmatch(contents)
+	if match == nil || len(match) != 2 {
+		return "", "", util.Errorf("could not extract aws_secret_access_key from %s", credPath)
+	}
+	key := match[1]
+
+	return string(keyID), string(key), nil
+}
+
+// ParseDockerMachineConfig takes an unmarshalled docker-machine json config and
+// extracts interesting fields from a docker machine amazon driver config.
+// TODO(marc): we should probably pull in docker machine here.
+func ParseDockerMachineConfig(config interface{}) (*NodeInfo, error) {
+	machineConfig, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, util.Errorf("unable to parse json machine config: %v", config)
+	}
+	driverConfig, ok := machineConfig["Driver"]
+	if !ok {
+		return nil, util.Errorf("missing key \"Driver\" in json config: %v", config)
+	}
+	awsConfig, ok := driverConfig.(map[string]interface{})
+	if !ok {
+		return nil, util.Errorf("unable to parse json driver config: %v", driverConfig)
+	}
+
+	instanceID, ok := awsConfig["InstanceId"]
+	if !ok {
+		return nil, util.Errorf("missing key \"InstanceId\" in driver config: %v", awsConfig)
+	}
+
+	securityGroupID, ok := awsConfig["SecurityGroupId"]
+	if !ok {
+		return nil, util.Errorf("missing key \"SecurityGroupId\" in driver config: %v", awsConfig)
+	}
+
+	ipAddress, ok := awsConfig["PrivateIPAddress"]
+	if !ok {
+		return nil, util.Errorf("missing key \"PrivateIPAddress\" in driver config: %v", awsConfig)
+	}
+
+	zone, ok := awsConfig["Zone"]
+	if !ok {
+		return nil, util.Errorf("missing key \"Zone\" in driver config: %v", awsConfig)
+	}
+
+	return &NodeInfo{
+		instanceID:       instanceID.(string),
+		securityGroupID:  securityGroupID.(string),
+		privateIPAddress: ipAddress.(string),
+		zone:             zone.(string),
+	}, nil
+}

--- a/drivers/amazon/vpc.go
+++ b/drivers/amazon/vpc.go
@@ -1,0 +1,52 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package amazon
+
+import (
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// FindDefaultVPC looks for the default VPC in a given region
+// and returns its ID if found.
+func FindDefaultVPC(region string) (string, error) {
+	ec2Service := ec2.New(&aws.Config{Region: region})
+
+	// Call the DescribeInstances Operation
+	resp, err := ec2Service.DescribeVPCs(&ec2.DescribeVPCsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("isDefault"),
+				Values: []*string{aws.String("true")},
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if len(resp.VPCs) == 0 {
+		return "", util.Errorf("no default VPC found in region %s", region)
+	}
+	if len(resp.VPCs) > 1 {
+		return "", util.Errorf("found %d default VPCs in region %s", len(resp.VPCs), region)
+	}
+
+	return *resp.VPCs[0].VPCID, nil
+}

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -1,0 +1,62 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package drivers
+
+import "github.com/cockroachdb/cockroach-prod/base"
+
+// Driver is the interface for all drivers.
+type Driver interface {
+	// Context returns the base context.
+	Context() *base.Context
+
+	// DockerMachineDriver returns the name of the docker-machine driver.
+	DockerMachineDriver() string
+
+	// Init is called when creating the driver. This will typically
+	// setup credentials.
+	Init() error
+
+	// DockerMachineCreateArgs returns the list of driver-specific arguments
+	// to pass to 'docker-machine create'
+	DockerMachineCreateArgs() []string
+
+	// PrintStatus asks the driver to print some basic status to stdout.
+	PrintStatus()
+
+	// GetNodeSettings takes a node name and unmarshalled json config
+	// and returns a filled in driver.NodeSettings.
+	GetNodeSettings(name string, config interface{}) (NodeSettings, error)
+
+	// ProcessFirstNode runs any steps needed after the first node was created.
+	// This takes the unmarshalled json config and node name.
+	ProcessFirstNode(name string, config interface{}) error
+
+	// AddNode runs any steps needed for new nodes (not just the first one).
+	// This takes the unmarshalled json config and node name.
+	AddNode(name string, config interface{}) error
+}
+
+// NodeSettings is a set of node parameters needed outside the driver.
+type NodeSettings interface {
+	// DataDir is the directory used as the data directory.
+	DataDir() string
+	// IPAddress is the node address cockroach should bind to.
+	IPAddress() string
+	// GossipAddress is the address to reach the gossip network.
+	GossipAddress() string
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,38 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cockroachdb/cockroach-prod/cli"
+)
+
+func init() {
+}
+
+func main() {
+	if len(os.Args) == 1 {
+		os.Args = append(os.Args, "help")
+	}
+	if err := cli.Run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed running command %q: %v\n", os.Args[1:], err)
+		os.Exit(1)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -24,9 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach-prod/cli"
 )
 
-func init() {
-}
-
 func main() {
 	if len(os.Args) == 1 {
 		os.Args = append(os.Args, "help")


### PR DESCRIPTION
For now: AWS only, and only create and initalizes the first node.
This includes load-balancer/security group glue for amazon.
    
Assuming you have docker and docker-machine installed and proper
aws credentials in ~/.aws/credentials, you can run:
  
```  
# Create cluster and initialize a single node.
./cockroach-prod init -region aws:us-east-1
# Add one node.
./cockroach-prod add-nodes region aws:us-east-1 1
# Lookup cluster status.
./cockroach-prod status -region aws:us-east-1
######## docker-machine ########
NAME          ACTIVE   DRIVER      STATE     URL                       SWARM
cockroach-0            amazonec2   Running   tcp://52.6.140.212:2376   
cockroach-1   *        amazonec2   Running   tcp://52.4.144.39:2376    

######### amazonec2 ########
Load balancer: cockroach-db-644706998.us-east-1.elb.amazonaws.com

# Talk to the cluster:
./cockroach scan --insecure --addr cockroach-db-644706998.us-east-1.elb.amazonaws.com:8080
```    

