### PR TITLE
Add start command to restart stopped nodes.

### DIFF
--- a/cli/add_nodes.go
+++ b/cli/add_nodes.go
@@ -15,8 +15,6 @@
 //
 // Author: Marc Berhault (marc@cockroachlabs.com)
 
-// The AWS library needs existing credentials.
-// See "Configuring Credentials" at: https://github.com/awslabs/aws-sdk-go
 package cli
 
 import (
@@ -32,7 +30,7 @@ import (
 
 var addNodesCmd = &commander.Command{
 	UsageLine: "add-nodes N",
-	Short:     "add new nodes",
+	Short:     "add new nodes\n",
 	Long: `
 Add N new nodes to an existing cluster
 `,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -89,6 +89,9 @@ var allCmds = &commander.Commander{
 		// Cluster setup.
 		initCmd,
 		addNodesCmd,
+
+		// Start and stop.
+		startCmd,
 		stopCmd,
 
 		// Status commands.

--- a/cli/init.go
+++ b/cli/init.go
@@ -15,8 +15,6 @@
 //
 // Author: Marc Berhault (marc@cockroachlabs.com)
 
-// The AWS library needs existing credentials.
-// See "Configuring Credentials" at: https://github.com/awslabs/aws-sdk-go
 package cli
 
 import (

--- a/cli/status.go
+++ b/cli/status.go
@@ -56,6 +56,7 @@ func runStatus(cmd *commander.Command, args []string) {
 	// Print docker-machine status.
 	fmt.Println("######## docker-machine ########")
 	c := exec.Command("docker-machine", "ls")
+	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	err := c.Run()

--- a/cli/status.go
+++ b/cli/status.go
@@ -15,8 +15,6 @@
 //
 // Author: Marc Berhault (marc@cockroachlabs.com)
 
-// The AWS library needs existing credentials.
-// See "Configuring Credentials" at: https://github.com/awslabs/aws-sdk-go
 package cli
 
 import (

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -36,6 +36,7 @@ const (
 // CheckDocker verifies that docker-machine is installed and runnable.
 func CheckDocker() error {
 	cmd := exec.Command("docker", "-v")
+	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
@@ -66,6 +67,7 @@ func RunDockerInit(context *base.Context, nodeName string, settings drivers.Node
 	)
 	log.Infof("running: docker %s", strings.Join(args, " "))
 	cmd := exec.Command("docker", args...)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -93,6 +95,7 @@ func RunDockerStart(context *base.Context, nodeName string, settings drivers.Nod
 	)
 	log.Infof("running: docker %s", strings.Join(args, " "))
 	cmd := exec.Command("docker", args...)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/docker/machine.go
+++ b/docker/machine.go
@@ -157,7 +157,16 @@ func CreateMachine(driver drivers.Driver, name string) error {
 	return cmd.Run()
 }
 
-// StopMachine invokes docker-machine stop on the given machine name.
+// StartMachine invokes "docker-machine start" on the given machine name.
+func StartMachine(name string) error {
+	log.Infof("starting docker machine %s", name)
+	cmd := exec.Command(dockerMachineBinary, "start", name)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
+}
+
+// StopMachine invokes "docker-machine stop" on the given machine name.
 func StopMachine(name string) error {
 	log.Infof("stopping docker machine %s", name)
 	cmd := exec.Command(dockerMachineBinary, "stop", name)

--- a/docker/machine.go
+++ b/docker/machine.go
@@ -52,6 +52,7 @@ func MakeNodeName(id int) string {
 // runnable.
 func CheckDockerMachine() error {
 	cmd := exec.Command(dockerMachineBinary, "-v")
+	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
@@ -152,6 +153,7 @@ func CreateMachine(driver drivers.Driver, name string) error {
 
 	log.Infof("running: %s %s", dockerMachineBinary, strings.Join(args, " "))
 	cmd := exec.Command(dockerMachineBinary, args...)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -161,6 +163,7 @@ func CreateMachine(driver drivers.Driver, name string) error {
 func StartMachine(name string) error {
 	log.Infof("starting docker machine %s", name)
 	cmd := exec.Command(dockerMachineBinary, "start", name)
+	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return cmd.Run()
@@ -170,6 +173,7 @@ func StartMachine(name string) error {
 func StopMachine(name string) error {
 	log.Infof("stopping docker machine %s", name)
 	cmd := exec.Command(dockerMachineBinary, "stop", name)
+	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return cmd.Run()

--- a/drivers/amazon/driver.go
+++ b/drivers/amazon/driver.go
@@ -184,7 +184,7 @@ func (a *Amazon) AddNode(name string, config interface{}) error {
 
 // StartNode adds the node to the load balancer.
 // ELB takes forever checking a stopped and started node,
-// so we have to re-register the node with the load balancer.
+// so we have to remove it at stopping time, and re-register it start time.
 func (a *Amazon) StartNode(name string, config interface{}) error {
 	nodeInfo, err := ParseDockerMachineConfig(config)
 	if err != nil {
@@ -199,9 +199,9 @@ func (a *Amazon) StartNode(name string, config interface{}) error {
 	return nil
 }
 
-// StopNode adds the node to the load balancer.
+// StopNode removes the node from the load balancer.
 // ELB takes forever checking a stopped and started node,
-// so we have to re-register the node with the load balancer.
+// so we have to remove it at stopping time, and re-register it start time.
 func (a *Amazon) StopNode(name string, config interface{}) error {
 	nodeInfo, err := ParseDockerMachineConfig(config)
 	if err != nil {

--- a/drivers/amazon/driver.go
+++ b/drivers/amazon/driver.go
@@ -177,8 +177,15 @@ func (a *Amazon) ProcessFirstNode(name string, config interface{}) error {
 }
 
 // AddNode runs any steps needed to add a node (any node, not just the first one).
-// This just adds the node to the load balancer.
+// This just adds the node to the load balancer, so for now, call StartNode.
 func (a *Amazon) AddNode(name string, config interface{}) error {
+	return a.StartNode(name, config)
+}
+
+// StartNode adds the node to the load balancer.
+// ELB takes forever checking a stopped and started node,
+// so we have to re-register the node with the load balancer.
+func (a *Amazon) StartNode(name string, config interface{}) error {
 	nodeInfo, err := ParseDockerMachineConfig(config)
 	if err != nil {
 		return err
@@ -188,6 +195,23 @@ func (a *Amazon) AddNode(name string, config interface{}) error {
 	err = AddNodeToELB(a.region, nodeInfo)
 	if err != nil {
 		return util.Errorf("failed to add node %+v to load balancer: %v", nodeInfo, err)
+	}
+	return nil
+}
+
+// StopNode adds the node to the load balancer.
+// ELB takes forever checking a stopped and started node,
+// so we have to re-register the node with the load balancer.
+func (a *Amazon) StopNode(name string, config interface{}) error {
+	nodeInfo, err := ParseDockerMachineConfig(config)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("removing node %+v from load balancer", nodeInfo)
+	err = RemoveNodeFromELB(a.region, nodeInfo)
+	if err != nil {
+		return util.Errorf("failed to remove node %+v from load balancer: %v", nodeInfo, err)
 	}
 	return nil
 }

--- a/drivers/amazon/elb.go
+++ b/drivers/amazon/elb.go
@@ -95,3 +95,14 @@ func AddNodeToELB(region string, info *NodeInfo) error {
 	})
 	return err
 }
+
+// RemoveNodeFromELB removes the specified node from the cockroach load balancer.
+// This can only succeed if the cockroach ELB exists.
+func RemoveNodeFromELB(region string, info *NodeInfo) error {
+	elbService := elb.New(&aws.Config{Region: region})
+	_, err := elbService.DeregisterInstancesFromLoadBalancer(&elb.DeregisterInstancesFromLoadBalancerInput{
+		LoadBalancerName: aws.String(cockroachELBName),
+		Instances:        []*elb.Instance{{InstanceID: aws.String(info.instanceID)}},
+	})
+	return err
+}

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -49,6 +49,14 @@ type Driver interface {
 	// AddNode runs any steps needed for new nodes (not just the first one).
 	// This takes the unmarshalled json config and node name.
 	AddNode(name string, config interface{}) error
+
+	// StartNode runs any steps needed when starting an existing node.
+	// This takes the unmarshalled json config and node name.
+	StartNode(name string, config interface{}) error
+
+	// StopNode runs any steps needed when stopping a node.
+	// This takes the unmarshalled json config and node name.
+	StopNode(name string, config interface{}) error
 }
 
 // NodeSettings is a set of node parameters needed outside the driver.


### PR DESCRIPTION
Small tweak: we need to de-register and re-register instances
with the load balancer, otherwise ELB takes forever to notice
the instance is in "running" state again.