### PR TITLE
Add GCE driver. OAuth setup only for now

### DIFF
--- a/base/context.go
+++ b/base/context.go
@@ -17,11 +17,19 @@
 
 package base
 
+import (
+	"log"
+	"os"
+	"os/user"
+)
+
 // Base context defaults.
 const (
-	defaultCerts  = "certs"
-	defaultPort   = 8080
-	defaultRegion = "aws:us-east-1"
+	defaultCerts        = "certs"
+	defaultPort         = 8080
+	defaultRegion       = ""
+	defaultGCEProject   = ""
+	defaultGCETokenPath = "${HOME}/.docker/machine/gce_token"
 )
 
 // Context is the base context object.
@@ -32,6 +40,12 @@ type Context struct {
 	Port int64
 	// Region to run in.
 	Region string
+
+	// Driver-specific flags.
+	// Project name for Google Compute Engine.
+	GCEProject string
+	// OAuth token path for Google Compute Engine.
+	GCETokenPath string
 }
 
 // NewContext returns a context with initialized values.
@@ -46,4 +60,14 @@ func (ctx *Context) InitDefaults() {
 	ctx.Certs = defaultCerts
 	ctx.Port = defaultPort
 	ctx.Region = defaultRegion
+	if len(defaultGCEProject) == 0 {
+		user, err := user.Current()
+		if err != nil {
+			log.Fatalf("failed to lookup current username: %v", err)
+		}
+		ctx.GCEProject = "cockroach-" + user.Username
+	} else {
+		ctx.GCEProject = defaultGCEProject
+	}
+	ctx.GCETokenPath = os.ExpandEnv(defaultGCETokenPath)
 }

--- a/base/context.go
+++ b/base/context.go
@@ -25,10 +25,10 @@ import (
 
 // Base context defaults.
 const (
-	defaultCerts        = "certs"
-	defaultPort         = 8080
-	defaultRegion       = ""
-	defaultGCEProject   = ""
+	defaultCerts  = "certs"
+	defaultPort   = 8080
+	defaultRegion = ""
+	// GCEProject defaults to "cockroach-${USER}"
 	defaultGCETokenPath = "${HOME}/.docker/machine/gce_token"
 )
 
@@ -60,14 +60,12 @@ func (ctx *Context) InitDefaults() {
 	ctx.Certs = defaultCerts
 	ctx.Port = defaultPort
 	ctx.Region = defaultRegion
-	if len(defaultGCEProject) == 0 {
-		user, err := user.Current()
-		if err != nil {
-			log.Fatalf("failed to lookup current username: %v", err)
-		}
-		ctx.GCEProject = "cockroach-" + user.Username
-	} else {
-		ctx.GCEProject = defaultGCEProject
+
+	user, err := user.Current()
+	if err != nil {
+		log.Fatalf("failed to lookup current username: %v", err)
 	}
+	ctx.GCEProject = "cockroach-" + user.Username
+
 	ctx.GCETokenPath = os.ExpandEnv(defaultGCETokenPath)
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach-prod/base"
 	"github.com/cockroachdb/cockroach-prod/drivers"
 	"github.com/cockroachdb/cockroach-prod/drivers/amazon"
+	"github.com/cockroachdb/cockroach-prod/drivers/google"
 	"github.com/cockroachdb/cockroach/util"
 
 	commander "code.google.com/p/go-commander"
@@ -59,8 +60,11 @@ func NewDriver(context *base.Context) (drivers.Driver, error) {
 
 	driver := tokens[0]
 	region := tokens[1]
-	if driver == "aws" {
+	switch driver {
+	case "aws":
 		return amazon.NewDriver(context, region), nil
+	case "gce":
+		return google.NewDriver(context, region), nil
 	}
 	return nil, util.Errorf("unknown driver: %s", driver)
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -30,9 +30,16 @@ func initFlags(ctx *base.Context) {
 
 	flag.Int64Var(&ctx.Port, "port", ctx.Port, "cockroach node and load balancer port.")
 
-	// TODO(marc): this may take a "cloud platform" attribute (eg: aws:<region> or gce:<region>).
-	// We will also need multi-region commands (eg: status, adding new region, etc...)
-	flag.StringVar(&ctx.Region, "region", ctx.Region, "region to run in.")
+	// Region to run in. This takes a driver attribute.
+	flag.StringVar(&ctx.Region, "region", ctx.Region, "region to run in. Specify a platform driver "+
+		"and region. AWS EC2: aws:us-east-1, Google Compute Engine: gce:us-central1.")
+
+	// Driver-specific flags.
+	flag.StringVar(&ctx.GCEProject, "gce-project", ctx.GCEProject, "project name for Google Compute "+
+		"engine. Defaults to \"cockroach-<local username>\".")
+
+	flag.StringVar(&ctx.GCETokenPath, "gce-auth-token", ctx.GCETokenPath, "path to the OAuth "+
+		"token for Google Compute Engine.")
 }
 
 func init() {

--- a/drivers/google/auth_util.go
+++ b/drivers/google/auth_util.go
@@ -1,0 +1,159 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+// This is a slight modification of: https://github.com/docker/machine/blob/master/drivers/google/auth_util.go
+// The main difference is that we have a single path for tokens, whereas docker-machine
+// has --google-auth-token and a default store-path.
+// Original license follows:
+
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package google
+
+import (
+	"encoding/gob"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"code.google.com/p/goauth2/oauth"
+	"github.com/docker/machine/log"
+	compute "google.golang.org/api/compute/v1"
+)
+
+const (
+	authURL  = "https://accounts.google.com/o/oauth2/auth"
+	tokenURL = "https://accounts.google.com/o/oauth2/token"
+	// Cockroach client ID and secret.
+	// TODO(marc): details show my personal email for now. We should have a more
+	// generic user-facing one.
+	clientId     = "962032490974-5avmqm15uklkgus98c7f862dk23u5mdk.apps.googleusercontent.com"
+	clientSecret = "SSytmGLypTUPnj6a3PeV8LiR"
+	redirectURI  = "urn:ietf:wg:oauth:2.0:oob"
+)
+
+func newGCEService(authTokenPath string) (*compute.Service, error) {
+	client := newOauthClient(authTokenPath)
+	service, err := compute.New(client)
+	return service, err
+}
+
+func newOauthClient(authTokenPath string) *http.Client {
+	config := &oauth.Config{
+		ClientId:     clientId,
+		ClientSecret: clientSecret,
+		Scope:        compute.ComputeScope,
+		AuthURL:      authURL,
+		TokenURL:     tokenURL,
+	}
+
+	token := token(authTokenPath, config)
+	t := oauth.Transport{
+		Token:     token,
+		Config:    config,
+		Transport: http.DefaultTransport,
+	}
+	return t.Client()
+}
+
+func token(tokenPath string, config *oauth.Config) *oauth.Token {
+	token, err := tokenFromCache(tokenPath)
+	if err != nil {
+		token = tokenFromWeb(config)
+		saveToken(tokenPath, token)
+	}
+	return token
+}
+
+func tokenFromCache(tokenPath string) (*oauth.Token, error) {
+	f, err := os.Open(tokenPath)
+	if err != nil {
+		return nil, err
+	}
+	token := new(oauth.Token)
+	err = gob.NewDecoder(f).Decode(token)
+	return token, err
+}
+
+func tokenFromWeb(config *oauth.Config) *oauth.Token {
+	randState := fmt.Sprintf("st%d", time.Now().UnixNano())
+
+	config.RedirectURL = redirectURI
+	authURL := config.AuthCodeURL(randState)
+
+	log.Info("Opening auth URL in browser.")
+	log.Info(authURL)
+	log.Info("If the URL doesn't open please open it manually and copy the code here.")
+	openURL(authURL)
+	code := getCodeFromStdin()
+
+	log.Infof("Got code: %s", code)
+
+	t := &oauth.Transport{
+		Config:    config,
+		Transport: http.DefaultTransport,
+	}
+	_, err := t.Exchange(code)
+	if err != nil {
+		log.Fatalf("Token exchange error: %v", err)
+	}
+	return t.Token
+}
+
+func getCodeFromStdin() string {
+	fmt.Print("Enter code: ")
+	var code string
+	fmt.Scanln(&code)
+	return strings.Trim(code, "\n")
+}
+
+func openURL(url string) {
+	try := []string{"xdg-open", "google-chrome", "open"}
+	for _, bin := range try {
+		err := exec.Command(bin, url).Run()
+		if err == nil {
+			return
+		}
+	}
+}
+
+func saveToken(tokenPath string, token *oauth.Token) {
+	log.Infof("Saving token in %v", tokenPath)
+	f, err := os.Create(tokenPath)
+	if err != nil {
+		log.Infof("Warning: failed to cache oauth token: %v", err)
+		return
+	}
+	defer f.Close()
+	gob.NewEncoder(f).Encode(token)
+}

--- a/drivers/google/auth_util.go
+++ b/drivers/google/auth_util.go
@@ -51,6 +51,12 @@ import (
 	compute "google.golang.org/api/compute/v1"
 )
 
+// OAuth logic. This initializes a GCE Service with a OAuth token.
+// If the token (in Gob format) exists at 'authTokenPath', load it.
+// Otherwise, redirect to the Google consent screen to get a code,
+// generate a token from it, and save it in 'authTokenPath'.
+//
+// The token file format must be the same as that used by docker-machine.
 const (
 	authURL  = "https://accounts.google.com/o/oauth2/auth"
 	tokenURL = "https://accounts.google.com/o/oauth2/token"

--- a/drivers/google/driver.go
+++ b/drivers/google/driver.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach-prod/base"
+	"github.com/cockroachdb/cockroach-prod/docker"
 	"github.com/cockroachdb/cockroach-prod/drivers"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/docker/machine/log"
 )
 
 const (
@@ -36,19 +38,24 @@ type Google struct {
 	project string
 }
 
-// TODO(marc): this is the old config setup. This need to change after the merge.
-type NodeInfo struct {
+// config contains the google-specific fields of the docker-machine config.
+// Not all are specified, only those used here.
+// Implements drivers.DriverConfig.
+type config struct {
 }
 
-func (n *NodeInfo) DataDir() string {
+// DataDir returns the data directory.
+func (cfg *config) DataDir() string {
 	return ""
 }
 
-func (n *NodeInfo) IPAddress() string {
+// IPAddress returns the IP address we will listen on.
+func (cfg *config) IPAddress() string {
 	return ""
 }
 
-func (n *NodeInfo) GossipAddress() string {
+// GossipAddress returns the address for the gossip network.
+func (cfg *config) GossipAddress() string {
 	return ""
 }
 
@@ -84,6 +91,7 @@ func (g *Google) Init() error {
 		return util.Errorf("invalid project %q: %v", g.project, err)
 	}
 
+	log.Infof("validated project name: %q", g.project)
 	// Return unimplemented for now so we don't proceed.
 	return util.Errorf("not implemented")
 }
@@ -103,28 +111,37 @@ func (g *Google) PrintStatus() {
 	fmt.Printf("Nothing yet")
 }
 
-// GetNodeSettings takes a node name and unmarshalled json config
-// and returns a filled NodeInfo.
-func (g *Google) GetNodeSettings(name string, config interface{}) (drivers.NodeSettings, error) {
-	return nil, util.Errorf("not implemented")
+// GetNodeConfig takes a node name and reads its docker-machine config.
+func (g *Google) GetNodeConfig(name string) (*drivers.HostConfig, error) {
+	cfg := &drivers.HostConfig{
+		Driver: &config{},
+	}
+
+	// Parse the config file.
+	err := docker.GetHostConfig(name, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, err
 }
 
-// ProcessFirstNode runs any steps needed after the first node was created.
-func (g *Google) ProcessFirstNode(name string, config interface{}) error {
+// AfterFirstNode runs any steps needed after the first node was created.
+func (g *Google) AfterFirstNode() error {
 	return util.Errorf("not implemented")
 }
 
 // AddNode runs any steps needed to add a node (any node, not just the first one).
-func (g *Google) AddNode(name string, config interface{}) error {
+func (g *Google) AddNode(name string, cfg *drivers.HostConfig) error {
 	return util.Errorf("not implemented")
 }
 
 // StartNode adds the node to the load balancer.
-func (g *Google) StartNode(name string, config interface{}) error {
+func (g *Google) StartNode(name string, cfg *drivers.HostConfig) error {
 	return util.Errorf("not implemented")
 }
 
 // StopNode removes the node from the load balancer.
-func (g *Google) StopNode(name string, config interface{}) error {
+func (g *Google) StopNode(name string, cfg *drivers.HostConfig) error {
 	return util.Errorf("not implemented")
 }

--- a/drivers/google/driver.go
+++ b/drivers/google/driver.go
@@ -27,19 +27,16 @@ import (
 
 const (
 	dockerMachineDriverName = "google"
-	cockroachClientID       = "962032490974-5avmqm15uklkgus98c7f862dk23u5mdk.apps.googleusercontent.com"
-	cockroachClientSecret   = "SSytmGLypTUPnj6a3PeV8LiR"
-	cockroachRedirectURI    = "urn:ietf:wg:oauth:2.0:oob"
 )
 
-// Google implements a driver for AWS.
+// Google implements a driver for Google Compute Engine.
 type Google struct {
 	context *base.Context
 	region  string
-
 	project string
 }
 
+// TODO(marc): this is the old config setup. This need to change after the merge.
 type NodeInfo struct {
 }
 
@@ -65,26 +62,26 @@ func NewDriver(context *base.Context, region string) *Google {
 }
 
 // Context returns the base context.
-func (a *Google) Context() *base.Context {
-	return a.context
+func (g *Google) Context() *base.Context {
+	return g.context
 }
 
 // DockerMachineDriver returns the name of the docker-machine driver.
-func (a *Google) DockerMachineDriver() string {
+func (g *Google) DockerMachineDriver() string {
 	return dockerMachineDriverName
 }
 
 // Init creates and compute client.
-func (a *Google) Init() error {
+func (g *Google) Init() error {
 	// Initialize auth: we re-use the code from docker-machine.
-	svc, err := newGCEService(a.context.GCETokenPath)
+	svc, err := newGCEService(g.context.GCETokenPath)
 	if err != nil {
 		return util.Errorf("could not get OAuth token: %v", err)
 	}
 
-	_, err = svc.Projects.Get(a.project).Do()
+	_, err = svc.Projects.Get(g.project).Do()
 	if err != nil {
-		return util.Errorf("invalid project %q: %v", a.project, err)
+		return util.Errorf("invalid project %q: %v", g.project, err)
 	}
 
 	// Return unimplemented for now so we don't proceed.
@@ -94,40 +91,40 @@ func (a *Google) Init() error {
 // DockerMachineCreateArgs returns the list of driver-specific arguments
 // to pass to 'docker-machine create'
 // TODO(marc): there are many other flags, see 'docker-machine help create'
-func (a *Google) DockerMachineCreateArgs() []string {
+func (g *Google) DockerMachineCreateArgs() []string {
 	return []string{
-		"--google-project", a.project,
-		"--google-auth-token", a.context.GCETokenPath,
+		"--google-project", g.project,
+		"--google-auth-token", g.context.GCETokenPath,
 	}
 }
 
 // PrintStatus prints the load balancer address to stdout.
-func (a *Google) PrintStatus() {
+func (g *Google) PrintStatus() {
 	fmt.Printf("Nothing yet")
 }
 
 // GetNodeSettings takes a node name and unmarshalled json config
 // and returns a filled NodeInfo.
-func (a *Google) GetNodeSettings(name string, config interface{}) (drivers.NodeSettings, error) {
+func (g *Google) GetNodeSettings(name string, config interface{}) (drivers.NodeSettings, error) {
 	return nil, util.Errorf("not implemented")
 }
 
 // ProcessFirstNode runs any steps needed after the first node was created.
-func (a *Google) ProcessFirstNode(name string, config interface{}) error {
+func (g *Google) ProcessFirstNode(name string, config interface{}) error {
 	return util.Errorf("not implemented")
 }
 
 // AddNode runs any steps needed to add a node (any node, not just the first one).
-func (a *Google) AddNode(name string, config interface{}) error {
+func (g *Google) AddNode(name string, config interface{}) error {
 	return util.Errorf("not implemented")
 }
 
 // StartNode adds the node to the load balancer.
-func (a *Google) StartNode(name string, config interface{}) error {
+func (g *Google) StartNode(name string, config interface{}) error {
 	return util.Errorf("not implemented")
 }
 
 // StopNode removes the node from the load balancer.
-func (a *Google) StopNode(name string, config interface{}) error {
+func (g *Google) StopNode(name string, config interface{}) error {
 	return util.Errorf("not implemented")
 }

--- a/drivers/google/driver.go
+++ b/drivers/google/driver.go
@@ -1,0 +1,133 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package google
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach-prod/base"
+	"github.com/cockroachdb/cockroach-prod/drivers"
+	"github.com/cockroachdb/cockroach/util"
+)
+
+const (
+	dockerMachineDriverName = "google"
+	cockroachClientID       = "962032490974-5avmqm15uklkgus98c7f862dk23u5mdk.apps.googleusercontent.com"
+	cockroachClientSecret   = "SSytmGLypTUPnj6a3PeV8LiR"
+	cockroachRedirectURI    = "urn:ietf:wg:oauth:2.0:oob"
+)
+
+// Google implements a driver for AWS.
+type Google struct {
+	context *base.Context
+	region  string
+
+	project string
+}
+
+type NodeInfo struct {
+}
+
+func (n *NodeInfo) DataDir() string {
+	return ""
+}
+
+func (n *NodeInfo) IPAddress() string {
+	return ""
+}
+
+func (n *NodeInfo) GossipAddress() string {
+	return ""
+}
+
+// NewDriver returns an initialized Google driver.
+func NewDriver(context *base.Context, region string) *Google {
+	return &Google{
+		context: context,
+		region:  region,
+		project: context.GCEProject,
+	}
+}
+
+// Context returns the base context.
+func (a *Google) Context() *base.Context {
+	return a.context
+}
+
+// DockerMachineDriver returns the name of the docker-machine driver.
+func (a *Google) DockerMachineDriver() string {
+	return dockerMachineDriverName
+}
+
+// Init creates and compute client.
+func (a *Google) Init() error {
+	// Initialize auth: we re-use the code from docker-machine.
+	svc, err := newGCEService(a.context.GCETokenPath)
+	if err != nil {
+		return util.Errorf("could not get OAuth token: %v", err)
+	}
+
+	_, err = svc.Projects.Get(a.project).Do()
+	if err != nil {
+		return util.Errorf("invalid project %q: %v", a.project, err)
+	}
+
+	// Return unimplemented for now so we don't proceed.
+	return util.Errorf("not implemented")
+}
+
+// DockerMachineCreateArgs returns the list of driver-specific arguments
+// to pass to 'docker-machine create'
+// TODO(marc): there are many other flags, see 'docker-machine help create'
+func (a *Google) DockerMachineCreateArgs() []string {
+	return []string{
+		"--google-project", a.project,
+		"--google-auth-token", a.context.GCETokenPath,
+	}
+}
+
+// PrintStatus prints the load balancer address to stdout.
+func (a *Google) PrintStatus() {
+	fmt.Printf("Nothing yet")
+}
+
+// GetNodeSettings takes a node name and unmarshalled json config
+// and returns a filled NodeInfo.
+func (a *Google) GetNodeSettings(name string, config interface{}) (drivers.NodeSettings, error) {
+	return nil, util.Errorf("not implemented")
+}
+
+// ProcessFirstNode runs any steps needed after the first node was created.
+func (a *Google) ProcessFirstNode(name string, config interface{}) error {
+	return util.Errorf("not implemented")
+}
+
+// AddNode runs any steps needed to add a node (any node, not just the first one).
+func (a *Google) AddNode(name string, config interface{}) error {
+	return util.Errorf("not implemented")
+}
+
+// StartNode adds the node to the load balancer.
+func (a *Google) StartNode(name string, config interface{}) error {
+	return util.Errorf("not implemented")
+}
+
+// StopNode removes the node from the load balancer.
+func (a *Google) StopNode(name string, config interface{}) error {
+	return util.Errorf("not implemented")
+}


### PR DESCRIPTION
We load the OAuth token from ~/.docker/machine/gce_token (default docker-machine path).
If not present, pop up a web auth request and generate the token, saving it for later use.

Small change: --region now defaults to "".