### PR TITLE
Implement steps needed for single-node cluster creation

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -61,8 +61,7 @@ func RunDockerInit(driver drivers.Driver, nodeName string, settings *drivers.Hos
 		"-v", fmt.Sprintf("%s:/data", settings.Driver.DataDir()),
 		"cockroachdb/cockroach",
 		"init",
-		"-insecure",
-		"-stores", "ssd=/data",
+		"--stores=ssd=/data",
 	)
 	log.Infof("running: docker %s", strings.Join(args, " "))
 	cmd := exec.Command("docker", args...)
@@ -88,10 +87,10 @@ func RunDockerStart(driver drivers.Driver, nodeName string, settings *drivers.Ho
 		"--net", "host",
 		"cockroachdb/cockroach",
 		"start",
-		"-insecure",
-		"-stores", "ssd=/data",
-		"-addr", fmt.Sprintf("%s:%d", settings.Driver.IPAddress(), port),
-		"-gossip", fmt.Sprintf("%s:%d", settings.Driver.GossipAddress(), port),
+		"--insecure",
+		"--stores=ssd=/data",
+		fmt.Sprintf("--addr=%s:%d", settings.Driver.IPAddress(), port),
+		fmt.Sprintf("--gossip=%s:%d", settings.Driver.GossipAddress(), port),
 	)
 	log.Infof("running: docker %s", strings.Join(args, " "))
 	cmd := exec.Command("docker", args...)

--- a/drivers/amazon/driver.go
+++ b/drivers/amazon/driver.go
@@ -30,7 +30,6 @@ import (
 const (
 	dockerMachineDriverName = "amazonec2"
 	amazonDataDir           = "/home/ubuntu/data"
-	cockroachProtocol       = "tcp"
 	defaultZone             = "a"
 )
 

--- a/drivers/amazon/security_group.go
+++ b/drivers/amazon/security_group.go
@@ -26,6 +26,7 @@ import (
 const (
 	securityGroupName             = "docker-machine"
 	allIPAddresses                = "0.0.0.0/0"
+	cockroachProtocol             = "tcp"
 	awsSecurityRuleDuplicateError = "InvalidPermission.Duplicate"
 	awsSecurityGroupNotFound      = "InvalidGroup.NotFound"
 )

--- a/drivers/google/auth_util.go
+++ b/drivers/google/auth_util.go
@@ -63,7 +63,7 @@ const (
 	// Cockroach client ID and secret.
 	// TODO(marc): details show my personal email for now. We should have a more
 	// generic user-facing one.
-	clientId     = "962032490974-5avmqm15uklkgus98c7f862dk23u5mdk.apps.googleusercontent.com"
+	clientID     = "962032490974-5avmqm15uklkgus98c7f862dk23u5mdk.apps.googleusercontent.com"
 	clientSecret = "SSytmGLypTUPnj6a3PeV8LiR"
 	redirectURI  = "urn:ietf:wg:oauth:2.0:oob"
 )
@@ -79,7 +79,7 @@ func newGCEService(authTokenPath string) (*compute.Service, error) {
 
 func newOauthClient(authTokenPath string) (*http.Client, error) {
 	config := &oauth.Config{
-		ClientId:     clientId,
+		ClientId:     clientID,
 		ClientSecret: clientSecret,
 		Scope:        compute.ComputeScope,
 		AuthURL:      authURL,

--- a/drivers/google/compute.go
+++ b/drivers/google/compute.go
@@ -1,0 +1,62 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package google
+
+import (
+	"fmt"
+
+	"google.golang.org/api/compute/v1"
+)
+
+const (
+	firewallName      = "cockroach"
+	cockroachProtocol = "tcp"
+	allIPAddresses    = "0.0.0.0/0"
+)
+
+// Check whether the named project exists. Returns nil if it does.
+func checkProjectExists(service *compute.Service, project string) error {
+	_, err := service.Projects.Get(project).Do()
+	return err
+}
+
+// Lookup and return the instance details.
+func getInstanceDetails(service *compute.Service, project, zone, machine string) (*compute.Instance, error) {
+	return service.Instances.Get(project, zone, machine).Do()
+}
+
+// Create firewall rule.
+// The API is happy inserting an existing one, so don't check for existence first.
+func createFirewallRule(service *compute.Service, project string, cockroachPort int64) error {
+	_, err := service.Firewalls.Insert(project,
+		&compute.Firewall{
+			Name: firewallName,
+			Allowed: []*compute.FirewallAllowed{
+				{
+					IPProtocol: cockroachProtocol,
+					Ports: []string{
+						fmt.Sprintf("%d", cockroachPort),
+					},
+				},
+			},
+			SourceRanges: []string{
+				allIPAddresses,
+			},
+		}).Do()
+	return err
+}


### PR DESCRIPTION
The main TODO for the rest is load balancer creation and node addition/removal from the load balancer.

So far, this can bring up a single-node cluster that uses itself as the gossip address.