### PR TITLE
Use oauth refresh tokens

### DIFF
--- a/cli/add_nodes.go
+++ b/cli/add_nodes.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach-prod/docker"
+	"github.com/cockroachdb/cockroach-prod/drivers"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/spf13/cobra"
@@ -46,9 +47,15 @@ func runAddNodes(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	driver, err := NewDriver(Context)
+	if err != nil {
+		log.Errorf("could not create driver: %v", err)
+		return
+	}
+
 	for i := 1; i <= numNodes; i++ {
 		log.Infof("adding node %d of %d", i, numNodes)
-		err := AddOneNode()
+		err := AddOneNode(driver)
 		if err != nil {
 			log.Errorf("problem adding node: %v", err)
 			return
@@ -57,17 +64,7 @@ func runAddNodes(cmd *cobra.Command, args []string) {
 }
 
 // AddOneNode is a helper to add a single node. Called repeatedly.
-func AddOneNode() error {
-	driver, err := NewDriver(Context)
-	if err != nil {
-		return util.Errorf("could not create driver: %v", err)
-	}
-
-	err = driver.Init()
-	if err != nil {
-		return util.Errorf("failed to initialized driver: %v", err)
-	}
-
+func AddOneNode(driver drivers.Driver) error {
 	nodes, err := docker.ListCockroachNodes()
 	if err != nil {
 		return util.Errorf("failed to get list of existing cockroach nodes: %v", err)

--- a/cli/init.go
+++ b/cli/init.go
@@ -39,12 +39,6 @@ func runInit(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	err = driver.Init()
-	if err != nil {
-		log.Errorf("failed to initialized driver: %v", err)
-		return
-	}
-
 	nodes, err := docker.ListCockroachNodes()
 	if err != nil {
 		log.Errorf("failed to get list of existing cockroach nodes: %v", err)

--- a/cli/start.go
+++ b/cli/start.go
@@ -39,12 +39,6 @@ func runStart(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	err = driver.Init()
-	if err != nil {
-		log.Errorf("failed to initialized driver: %v", err)
-		return
-	}
-
 	// TODO(marc): only get nodes in state "Stopped".
 	nodes, err := docker.ListCockroachNodes()
 	if err != nil {

--- a/cli/status.go
+++ b/cli/status.go
@@ -50,31 +50,26 @@ func runStatus(cmd *cobra.Command, args []string) {
 	}
 	log.Info("docker binary found")
 
-	// Print docker-machine status.
-	fmt.Println("######## docker-machine ########")
-	c := exec.Command("docker-machine", "ls")
-	c.Stdin = os.Stdin
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	err := c.Run()
-
-	if err != nil {
-		log.Error(err)
-	}
-
-	// Get driver-specific status.
+	// Initialize driver: this refreshes oauth.
 	driver, err := NewDriver(Context)
 	if err != nil {
 		log.Errorf("could not create driver: %v", err)
 		return
 	}
 
-	err = driver.Init()
+	// Print docker-machine status.
+	fmt.Println("######## docker-machine ########")
+	c := exec.Command("docker-machine", "ls")
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	err = c.Run()
+
 	if err != nil {
-		log.Errorf("failed to initialized driver: %v", err)
-		return
+		log.Error(err)
 	}
 
+	// Get driver-specific status.
 	fmt.Printf("\n######### %s ########\n", driver.DockerMachineDriver())
 	driver.PrintStatus()
 }

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -39,12 +39,6 @@ func runStop(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	err = driver.Init()
-	if err != nil {
-		log.Errorf("failed to initialized driver: %v", err)
-		return
-	}
-
 	// TODO(marc): only get nodes in state "Running".
 	nodes, err := docker.ListCockroachNodes()
 	if err != nil {

--- a/drivers/google/auth_util.go
+++ b/drivers/google/auth_util.go
@@ -88,6 +88,7 @@ func (f gobCache) Token() (*oauth.Token, error) {
 }
 
 // PutToken stores the given token in the cache.
+// TODO(marc): we should write to a tmp file and rename in case we error out.
 func (f gobCache) PutToken(tok *oauth.Token) error {
 	file, err := os.OpenFile(string(f), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
@@ -139,6 +140,7 @@ func initTransport(transport *oauth.Transport) error {
 		}
 
 		// Token is expired, attempt a refresh.
+		// TODO(marc): we should check whether it expires soon (eg: 5 minutes).
 		err := transport.Refresh()
 		if err == nil {
 			return nil

--- a/drivers/google/auth_util.go
+++ b/drivers/google/auth_util.go
@@ -68,13 +68,39 @@ const (
 	redirectURI  = "urn:ietf:wg:oauth:2.0:oob"
 )
 
-func newGCEService(authTokenPath string) (*compute.Service, error) {
-	client, err := newOauthClient(authTokenPath)
+// gobCache implements oauth.Cache.
+// Its value is the full path name to the cache file.
+// This is pretty much oauth.CacheFile, but with gob encoding.
+type gobCache string
+
+// Token returns the cached token value, or an error if none is found.
+func (f gobCache) Token() (*oauth.Token, error) {
+	file, err := os.Open(string(f))
 	if err != nil {
 		return nil, err
 	}
-	service, err := compute.New(client)
-	return service, err
+	defer file.Close()
+	tok := &oauth.Token{}
+	if err = gob.NewDecoder(file).Decode(tok); err != nil {
+		return nil, err
+	}
+	return tok, nil
+}
+
+// PutToken stores the given token in the cache.
+func (f gobCache) PutToken(tok *oauth.Token) error {
+	file, err := os.OpenFile(string(f), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	if err := gob.NewEncoder(file).Encode(tok); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func newOauthClient(authTokenPath string) (*http.Client, error) {
@@ -84,69 +110,57 @@ func newOauthClient(authTokenPath string) (*http.Client, error) {
 		Scope:        compute.ComputeScope,
 		AuthURL:      authURL,
 		TokenURL:     tokenURL,
+		RedirectURL:  redirectURI,
+		TokenCache:   gobCache(authTokenPath),
+		// Needed for refresh tokens:
+		AccessType:     "offline",
+		ApprovalPrompt: "force",
 	}
 
-	token, err := getToken(authTokenPath, config)
-	if err != nil {
-		return nil, err
-	}
-
-	t := oauth.Transport{
-		Token:     token,
+	transport := &oauth.Transport{
 		Config:    config,
 		Transport: http.DefaultTransport,
 	}
-	return t.Client(), nil
-}
 
-func getToken(tokenPath string, config *oauth.Config) (*oauth.Token, error) {
-	token, err := tokenFromCache(tokenPath)
-	if err == nil {
-		return token, nil
-	}
-
-	token, err = tokenFromWeb(config)
+	err := initTransport(transport)
 	if err != nil {
 		return nil, err
 	}
-
-	saveToken(tokenPath, token)
-	return token, nil
+	return transport.Client(), nil
 }
 
-func tokenFromCache(tokenPath string) (*oauth.Token, error) {
-	f, err := os.Open(tokenPath)
-	if err != nil {
-		return nil, err
+func initTransport(transport *oauth.Transport) error {
+	// First: check the cache.
+	if token, err := transport.Config.TokenCache.Token(); err == nil {
+		// We have a token.
+		transport.Token = token
+		if !token.Expired() {
+			return nil
+		}
+
+		// Token is expired, attempt a refresh.
+		err := transport.Refresh()
+		if err == nil {
+			return nil
+		}
+		log.Infof("token expired and refresh failed, requesting new one")
 	}
-	token := new(oauth.Token)
-	err = gob.NewDecoder(f).Decode(token)
-	return token, err
-}
 
-func tokenFromWeb(config *oauth.Config) (*oauth.Token, error) {
+	// Get a new token. Pops up a browser window (hopefully).
 	randState := fmt.Sprintf("st%d", time.Now().UnixNano())
-
-	config.RedirectURL = redirectURI
-	authURL := config.AuthCodeURL(randState)
-
-	log.Info("Opening auth URL in browser.")
-	log.Info(authURL)
-	log.Info("If the URL doesn't open please open it manually and copy the code here.")
+	authURL := transport.Config.AuthCodeURL(randState)
+	log.Infof("Opening auth URL in browser: %s", authURL)
+	log.Infof("If the URL doesn't open please open it manually and copy the code here.")
 	openURL(authURL)
 	code := getCodeFromStdin()
 
-	log.Infof("Got code: %s", code)
-
-	t := &oauth.Transport{
-		Config:    config,
-		Transport: http.DefaultTransport,
-	}
-	_, err := t.Exchange(code)
+	_, err := transport.Exchange(code)
 	if err != nil {
-		return nil, err
+		log.Infof("problem exchanging code: %v", err)
+		return err
 	}
-	return t.Token, nil
+
+	return nil
 }
 
 func getCodeFromStdin() string {
@@ -164,15 +178,4 @@ func openURL(url string) {
 			return
 		}
 	}
-}
-
-func saveToken(tokenPath string, token *oauth.Token) {
-	log.Infof("Saving token in %v", tokenPath)
-	f, err := os.Create(tokenPath)
-	if err != nil {
-		log.Infof("Warning: failed to cache oauth token: %v", err)
-		return
-	}
-	defer f.Close()
-	gob.NewEncoder(f).Encode(token)
 }

--- a/drivers/google/driver.go
+++ b/drivers/google/driver.go
@@ -95,9 +95,14 @@ func (g *Google) DockerMachineDriver() string {
 // Init creates and and initializes the compute client.
 func (g *Google) Init() error {
 	// Initialize auth: we re-use the code from docker-machine.
-	svc, err := newGCEService(g.context.GCETokenPath)
+	oauthClient, err := newOauthClient(g.context.GCETokenPath)
 	if err != nil {
-		return util.Errorf("could not get OAuth token: %v", err)
+		return util.Errorf("could not get OAuth client: %v", err)
+	}
+
+	svc, err := compute.New(oauthClient)
+	if err != nil {
+		return util.Errorf("could not get Compute service: %v", err)
 	}
 	g.computeService = svc
 
@@ -124,6 +129,7 @@ func (g *Google) PrintStatus() {
 	rule, err := lookupForwardingRule(g.computeService, g.project, g.region)
 	if err != nil {
 		fmt.Println("Forwarding Rule: not found:", err)
+		return
 	}
 	fmt.Printf("Forwarding Rule: %s:%d\n", rule.IPAddress, g.context.Port)
 }


### PR DESCRIPTION
Basic tokens expired after 1h, which really does us no good.
Instead, request refresh tokens, and perform the refresh if the token is expired. This is checked at driver.Init() time (we should probably check if it expires soon. eg: within 5 minutes or so)