### PR TITLE
Use AWS library to load credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Creating a cockroach cluster with 3 nodes is done as follows:
 #### Prerequisites
 
 * AWS account
-* AWS credentials in `~/.aws/credentials`. See [AWS cli configuration](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) 
+* AWS credentials in `~/.aws/credentials` or environment variables. See [AWS cli configuration](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) 
 
 #### Driver
 

--- a/drivers/amazon/utils.go
+++ b/drivers/amazon/utils.go
@@ -17,10 +17,7 @@
 
 package amazon
 
-import (
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/cockroachdb/cockroach/util"
-)
+import "github.com/awslabs/aws-sdk-go/aws"
 
 // LoadAWSCredentials loads the credentials using the AWS api. This automatically
 // loads from ENV, or from the .aws/credentials file.
@@ -28,7 +25,7 @@ import (
 func LoadAWSCredentials() (string, string, error) {
 	creds, err := aws.DefaultCreds().Credentials()
 	if err != nil {
-		return "", "", util.Errorf("could not load AWS credentials: %s", err)
+		return "", "", err
 	}
 
 	return creds.AccessKeyID, creds.SecretAccessKey, nil


### PR DESCRIPTION
Much more reliable. Also handles credentials in env variables, and the more advanced .aws/credentials file format.