### PR TITLE
Start/stop specific nodes. Fix --addr

### DIFF
--- a/cli/add_nodes.go
+++ b/cli/add_nodes.go
@@ -70,7 +70,7 @@ func AddOneNode(driver drivers.Driver) error {
 		return util.Errorf("failed to get list of existing cockroach nodes: %v", err)
 	}
 	if len(nodes) == 0 {
-		return util.Errorf("no existing cockroach nodes detected, this means there is probably no existing cluster")
+		return util.Errorf("no existing cockroach nodes detected, does the cluster exist?")
 	}
 
 	largestIndex, err := docker.GetLargestNodeIndex(nodes)

--- a/cli/start.go
+++ b/cli/start.go
@@ -27,7 +27,7 @@ var startCmd = &cobra.Command{
 	Use:   "start [<node 1> <node2>]",
 	Short: "start nodes",
 	Long: `
-Start specified nodes, or all if none passed. They must have been previously added and stopped.
+Start specified nodes, or all if blank. They must have been previously added and stopped.
 `,
 	Run: runStart,
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -24,10 +24,10 @@ import (
 )
 
 var startCmd = &cobra.Command{
-	Use:   "start",
-	Short: "start all nodes",
+	Use:   "start [<node 1> <node2>]",
+	Short: "start nodes",
 	Long: `
-Start all nodes. They must have been previously added and stopped.
+Start specified nodes, or all if none passed. They must have been previously added and stopped.
 `,
 	Run: runStart,
 }
@@ -39,15 +39,21 @@ func runStart(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// TODO(marc): only get nodes in state "Stopped".
-	nodes, err := docker.ListCockroachNodes()
-	if err != nil {
-		log.Errorf("failed to get list of existing cockroach nodes: %v", err)
-		return
-	}
-	if len(nodes) == 0 {
-		log.Errorf("no existing cockroach nodes detected, this means there is probably no existing cluster")
-		return
+	var nodes []string
+	if len(args) == 0 {
+		// TODO(marc): only get nodes in state "Stopped".
+		nodes, err := docker.ListCockroachNodes()
+		if err != nil {
+			log.Errorf("failed to get list of existing cockroach nodes: %v", err)
+			return
+		}
+		if len(nodes) == 0 {
+			log.Errorf("no existing cockroach nodes detected, this means there is probably no existing cluster")
+			return
+		}
+	} else {
+		// We let docker-machine dump errors if nodes do not exist.
+		nodes = args
 	}
 
 	for _, nodeName := range nodes {

--- a/cli/start.go
+++ b/cli/start.go
@@ -42,7 +42,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	var nodes []string
 	if len(args) == 0 {
 		// TODO(marc): only get nodes in state "Stopped".
-		nodes, err := docker.ListCockroachNodes()
+		nodes, err = docker.ListCockroachNodes()
 		if err != nil {
 			log.Errorf("failed to get list of existing cockroach nodes: %v", err)
 			return

--- a/cli/start.go
+++ b/cli/start.go
@@ -24,7 +24,7 @@ import (
 )
 
 var startCmd = &cobra.Command{
-	Use:   "start [<node 1> <node2>]",
+	Use:   "start [<node> ... <node>]",
 	Short: "start nodes",
 	Long: `
 Start specified nodes, or all if blank. They must have been previously added and stopped.

--- a/cli/start.go
+++ b/cli/start.go
@@ -48,7 +48,7 @@ func runStart(cmd *cobra.Command, args []string) {
 			return
 		}
 		if len(nodes) == 0 {
-			log.Errorf("no existing cockroach nodes detected, this means there is probably no existing cluster")
+			log.Errorf("no existing cockroach nodes detected, does the cluster exist?")
 			return
 		}
 	} else {

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -27,7 +27,7 @@ var stopCmd = &cobra.Command{
 	Use:   "stop [<node 1> <node2>]",
 	Short: "stop nodes\n",
 	Long: `
-Stop specified nodes, or all if none passed. This stops the actual cloud instances.
+Stop specified nodes, or all if blank. This stops the actual cloud instances.
 `,
 	Run: runStop,
 }

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -24,7 +24,7 @@ import (
 )
 
 var stopCmd = &cobra.Command{
-	Use:   "stop [<node 1> <node2>]",
+	Use:   "stop [<node> ... <node>]",
 	Short: "stop nodes\n",
 	Long: `
 Stop specified nodes, or all if blank. This stops the actual cloud instances.

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -42,7 +42,7 @@ func runStop(cmd *cobra.Command, args []string) {
 	var nodes []string
 	if len(args) == 0 {
 		// TODO(marc): only get nodes in state "Running".
-		nodes, err := docker.ListCockroachNodes()
+		nodes, err = docker.ListCockroachNodes()
 		if err != nil {
 			log.Errorf("failed to get list of existing cockroach nodes: %v", err)
 			return

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -24,10 +24,10 @@ import (
 )
 
 var stopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "stop all nodes\n",
+	Use:   "stop [<node 1> <node2>]",
+	Short: "stop nodes\n",
 	Long: `
-Stop all nodes. This stops the actual cloud instances.
+Stop specified nodes, or all if none passed. This stops the actual cloud instances.
 `,
 	Run: runStop,
 }
@@ -39,15 +39,21 @@ func runStop(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// TODO(marc): only get nodes in state "Running".
-	nodes, err := docker.ListCockroachNodes()
-	if err != nil {
-		log.Errorf("failed to get list of existing cockroach nodes: %v", err)
-		return
-	}
-	if len(nodes) == 0 {
-		log.Errorf("no existing cockroach nodes detected, this means there is probably no existing cluster")
-		return
+	var nodes []string
+	if len(args) == 0 {
+		// TODO(marc): only get nodes in state "Running".
+		nodes, err := docker.ListCockroachNodes()
+		if err != nil {
+			log.Errorf("failed to get list of existing cockroach nodes: %v", err)
+			return
+		}
+		if len(nodes) == 0 {
+			log.Errorf("no existing cockroach nodes detected, this means there is probably no existing cluster")
+			return
+		}
+	} else {
+		// We let docker-machine dump errors if nodes do not exist.
+		nodes = args
 	}
 
 	for _, nodeName := range nodes {

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -48,7 +48,7 @@ func runStop(cmd *cobra.Command, args []string) {
 			return
 		}
 		if len(nodes) == 0 {
-			log.Errorf("no existing cockroach nodes detected, this means there is probably no existing cluster")
+			log.Errorf("no existing cockroach nodes detected, does the cluster exist?")
 			return
 		}
 	} else {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -89,9 +89,8 @@ func RunDockerStart(driver drivers.Driver, nodeName string, settings *drivers.Ho
 		"start",
 		"--insecure",
 		"--stores=ssd=/data",
-		// TODO(marc): we may need ip:port for TLS. Use settings.Driver.IPAddress()
-		// For now, it causes problems with GCE's network forwarding, so skip it.
-		fmt.Sprintf("--addr=:%d", port),
+		// --addr must be an address reachable by other nodes.
+		fmt.Sprintf("--addr=%s:%d", settings.Driver.IPAddress(), port),
 		// TODO(marc): remove localhost once we serve /_status/ before
 		// joining the gossip network.
 		fmt.Sprintf("--gossip=localhost:%d,http-lb=%s:%d", port, settings.Driver.GossipAddress(), port),


### PR DESCRIPTION
Add ability to start/stop specific nodes. Useful when docker-machine screws up.
Also specify the ip address in --addr at start time. Needed when using --gossip=http-lb=...