### PR TITLE
Cockroach config for AWS using terraform

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,2 @@
+*.backup
+*.tfstate

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -160,6 +160,13 @@ cockroach.WARNING
 
 ```
 
+#### Profile servers
+
+Using either the ELB address (will hit a random node), or a specific instance:
+```
+$ go tool pprof <address:port>/debug/pprof/profile
+```
+
 ## Destroy the cluster
 
 ```

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -1,0 +1,173 @@
+# Deploy cockroach cluster on AWS using Terraform
+
+This directory contains the [Terraform](https://terraform.io/) configuration
+files needed to launch a cockroach cluster on AWS.
+
+The following steps will create a three node cluster.
+
+## One-time setup steps
+1. Have an [AWS](http://aws.amazon.com/) account
+2. [Download terraform](https://terraform.io/downloads.html), unzip, and add to your `PATH`.
+3. [Find your AWS credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html#cli-signup). Save them as environment variables `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`.
+4. [Create an AWS keypair](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:sort=keyName) named `cockroach` and save the file as `~/.ssh/cockroach.pem`.
+5. Check out the [Cockroach repository](https://github.com/cockroachdb/cockroach) and build the cockroach binary. It must be located at `~/cockroach/src/github.com/cockroachdb/cockroach/cockroach` (adjust `cockroach_binary` in `variables.tf` otherwise).
+
+## Variables
+
+The following variables can be modified in `variables.tf` if necessary.
+* `cockroach_port`: the port for the backends and load balancer
+* `aws_region`: region to run in. Affects `aws_availability_zone` and `aws_ami_id`
+* `aws_availability_zone`: availability zone for instances and load balancer
+* `aws_ami_id`: image ID. depends on the region.
+* `cockroach_binary`: path to the cockroach binary
+* `key_name`: base name of the AWS key
+* `action`: default action. Defaults to `start`. Override is specified in initialization step
+
+## Create the cluster
+
+The following three commands will initialize all needed AWS infrastructure in the region `us-east-1`,
+initialize the first cockroach node, then add two more nodes to the cluster.
+All dynamic configuration is set through terraform command-line flags but can be set in `variables.tf`.
+
+To see the actions expected to be performed by terraform, use `plan` instead of `apply`.
+
+#### Initialize AWS infrastructure
+
+```
+$ terraform apply \
+    --var=aws_access_key="${AWS_ACCESS_KEY}" \
+    --var=aws_secret_key="${AWS_SECRET_KEY}" \
+    --var=gossip=""                       \
+    --var=num_instances=0
+
+aws_security_group.default: Creating...
+aws_security_group.default: Creation complete
+aws_elb.elb: Creating...
+aws_elb.elb: Creation complete
+Outputs:
+  elb             = elb-1289187553.us-east-1.elb.amazonaws.com
+  gossip_variable = elb-1289187553.us-east-1.elb.amazonaws.com:26257
+  instances       = 
+  port            = 26257
+
+```
+
+This command creates a load balancer and displays the value of the gossip flag to be used in the
+following steps.
+
+Save the elb address and port as an environment variable:
+```
+$ export ELB="elb-1289187553.us-east-1.elb.amazonaws.com:26257"
+```
+
+#### Initialize the first node
+
+```
+$ terraform apply \
+    --var=aws_access_key="${AWS_ACCESS_KEY}" \
+    --var=aws_secret_key="${AWS_SECRET_KEY}" \
+    --var=gossip="lb=${ELB}" \
+    --var=num_instances=1                 \
+    --var=action="init"
+
+aws_security_group.default: Refreshing state... (ID: sg-828435e4)
+aws_elb.elb: Refreshing state... (ID: elb)
+aws_instance.cockroach: Creating...
+aws_instance.cockroach: Provisioning with 'file'...
+aws_instance.cockroach: Provisioning with 'file'...
+aws_instance.cockroach: Provisioning with 'remote-exec'...
+aws_instance.cockroach: Creation complete
+aws_elb.elb: Modifying...
+aws_elb.elb: Modifications complete
+Outputs:
+  elb             = elb-1289187553.us-east-1.elb.amazonaws.com
+  gossip_variable = elb-1289187553.us-east-1.elb.amazonaws.com:26257
+  instances       = ec2-54-85-12-159.compute-1.amazonaws.com
+  port            = 26257
+
+```
+
+The `--var=action="init"` parameter causes the first node to be initialized for with a new cluster.
+The cluster is now running with a single node and is reachable through the load balancer (see `Using the cluster`).
+
+#### Add more nodes to the cluster
+
+```
+$ terraform apply \
+    --var=aws_access_key="${AWS_ACCESS_KEY}" \
+    --var=aws_secret_key="${AWS_SECRET_KEY}" \
+    --var=gossip="lb=${ELB}" \
+    --var=num_instances=3
+
+aws_security_group.default: Refreshing state... (ID: sg-828435e4)
+aws_instance.cockroach.0: Refreshing state... (ID: i-1d10fbca)
+aws_elb.elb: Refreshing state... (ID: elb)
+aws_instance.cockroach.1: Creating...
+aws_instance.cockroach.2: Creating...
+aws_instance.cockroach.2: Provisioning with 'file'...
+aws_instance.cockroach.1: Provisioning with 'file'...
+aws_instance.cockroach.2: Provisioning with 'remote-exec'...
+aws_instance.cockroach.2: Creation complete
+aws_instance.cockroach.1: Provisioning with 'remote-exec'...
+aws_instance.cockroach.1: Creation complete
+aws_elb.elb: Modifying...
+aws_elb.elb: Modifications complete
+Outputs:
+  elb             = elb-1289187553.us-east-1.elb.amazonaws.com
+  gossip_variable = elb-1289187553.us-east-1.elb.amazonaws.com:26257
+  instances       = ec2-54-85-12-159.compute-1.amazonaws.com,ec2-54-175-192-198.compute-1.amazonaws.com,ec2-54-88-84-13.compute-1.amazonaws.com
+  port            = 26257
+
+```
+
+## Use the cluster
+
+#### Connect to the cluster
+
+Use the load balancer address to connect to the cluster. You may need to wait a few minutes after
+ELB creation for its DNS name to be resolvable.
+
+```
+$ ./cockroach sql --insecure --addr=${ELB}
+elb-1289187553.us-east-1.elb.amazonaws.com:26257> show databases;
++----------+
+| Database |
++----------+
+| system   |
++----------+
+```
+
+#### Ssh into individual instances
+
+The DNS names of AWS instances is shown as a comma-separated list in the terraform output.
+
+```
+$ ssh -i ~/.ssh/cockroach.pem ubuntu@ec2-54-85-12-159.compute-1.amazonaws.com
+
+ubuntu@ip-172-31-15-87:~$ ps -Af|grep cockroach
+ubuntu    1448     1  4 20:03 ?        00:00:39 ./cockroach start --log-dir=logs --logtostderr=false --stores=ssd=data --insecure --gossip=lb=${ELB}
+
+ubuntu@ip-172-31-15-87:~$ ls logs
+cockroach.ERROR
+cockroach.INFO
+cockroach.ip-172-31-15-87.ubuntu.log.ERROR.2015-11-02T20_03_14Z.1448
+cockroach.ip-172-31-15-87.ubuntu.log.INFO.2015-11-02T20_03_09Z.1443
+cockroach.ip-172-31-15-87.ubuntu.log.INFO.2015-11-02T20_03_09Z.1448
+cockroach.ip-172-31-15-87.ubuntu.log.WARNING.2015-11-02T20_03_09Z.1448
+cockroach.STDERR
+cockroach.STDOUT
+cockroach.WARNING
+
+```
+
+## Destroy the cluster
+
+```
+$ terraform destroy \
+    --var=aws_access_key="${AWS_ACCESS_KEY}" \
+    --var=aws_secret_key="${AWS_SECRET_KEY}" \
+    --var=gossip="lb=${ELB}" \
+    --var=num_instances=3
+```
+
+The destroy command requires confirmation.

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -167,6 +167,10 @@ Using either the ELB address (will hit a random node), or a specific instance:
 $ go tool pprof <address:port>/debug/pprof/profile
 ```
 
+#### Running examples against the cockroach cluster
+
+See `examples.tf` for sample examples and how to run them against the created cluster.
+
 ## Destroy the cluster
 
 ```

--- a/terraform/aws/elb.tf
+++ b/terraform/aws/elb.tf
@@ -1,0 +1,29 @@
+resource "aws_elb" "elb" {
+  name = "elb"
+
+  security_groups = ["${aws_security_group.default.id}"]
+  availability_zones = [ "${var.aws_availability_zone}" ]
+  listener {
+    instance_port = "${var.cockroach_port}"
+    instance_protocol = "tcp"
+    lb_port = "${var.cockroach_port}"
+    lb_protocol = "tcp"
+  }
+
+  health_check {
+    healthy_threshold = 2
+    unhealthy_threshold = 2
+    timeout = 2
+    interval = 5
+    target = "${format("TCP:%s", "${var.cockroach_port}")}"
+  }
+
+  # Note: when there are no instances, aws_instance.cockroach.*.id has an empty
+  # element, causing failed elb updates. See: https://github.com/hashicorp/terraform/issues/3581
+  instances = ["${compact(split(",", join(",",aws_instance.cockroach.*.id)))}"]
+
+  cross_zone_load_balancing = true
+  idle_timeout = 400
+  connection_draining = true
+  connection_draining_timeout = 400
+}

--- a/terraform/aws/examples.tf
+++ b/terraform/aws/examples.tf
@@ -1,0 +1,46 @@
+# Various examples that can be run against a cockroach cluster in AWS.
+# A cockroach cluster should be created first by following the steps in README.md.
+# To enable an example, change the number of instances on the command line. eg:
+# terraform apply <flags for cockroach cluster> --var=example_block_writer_instances=1
+# See the "provisioner file" stanza for the desired path to the built linux binary.
+
+# Number of instances for the block writer example. Set to 1 to enable the example.
+# The block writer example does not support multiple instances. Expect badness if
+# set greater than 1.
+variable "example_block_writer_instances" {
+  default = 0
+}
+output "example_block_writers" {
+  value = "${join(",", aws_instance.example_block_writer.*.public_dns)}"
+}
+
+resource "aws_instance" "example_block_writer" {
+    tags {
+      Name = "example-block-writer"
+    }
+
+    ami = "${var.aws_ami_id}"
+    availability_zone = "${var.aws_availability_zone}"
+    instance_type = "t1.micro"
+    security_groups = ["${aws_security_group.default.name}"]
+    key_name = "${var.key_name}"
+    count = "${var.example_block_writer_instances}"
+
+    connection {
+      user = "ubuntu"
+      key_file = "~/.ssh/${var.key_name}.pem"
+    }
+
+    provisioner "file" {
+        source = "../../../examples-go/block_writer/block_writer"
+        destination = "/home/ubuntu/block_writer"
+    }
+
+   provisioner "remote-exec" {
+        inline = [
+          "chmod 755 block_writer",
+          "nohup ./block_writer --db-url=http://${aws_elb.elb.dns_name}:${var.cockroach_port} > example.STDOUT 2>&1 &",
+          "sleep 5",
+        ]
+   }
+}

--- a/terraform/aws/launch.sh
+++ b/terraform/aws/launch.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# This is a simple wrapper script around the cockroach binary.
+# It must be in the same directory as the cockroach binary, and invoked in one of two ways:
+#
+# To start the first node and initialize the cluster:
+# ./launch init [gossip flag value]
+# To start a node:
+# ./launch start [gossip flag value]
+set -ex
+
+DATA_DIR="data"
+LOG_DIR="logs"
+STORES="ssd=${DATA_DIR}"
+COMMON_FLAGS="--log-dir=${LOG_DIR} --logtostderr=false --stores=${STORES}"
+START_FLAGS="--insecure"
+
+action=$1
+if [ "${action}" != "init" -a "${action}" != "start" ]; then
+  echo "Usage: ${0} [init|start] [gossip flag value]"
+  exit 1
+fi
+
+gossip=$2
+if [ -z "${gossip}" ]; then
+  echo "Usage: ${0} [init|start] [gossip flag value]"
+  exit 1
+fi
+
+chmod 755 cockroach
+mkdir -p ${DATA_DIR} ${LOG_DIR}
+
+if [ "${action}" == "init" ]; then
+  ./cockroach init ${COMMON_FLAGS}
+fi
+
+cmd="./cockroach start ${COMMON_FLAGS} ${START_FLAGS} --gossip=${gossip}"
+nohup ${cmd} > ${LOG_DIR}/cockroach.STDOUT 2> ${LOG_DIR}/cockroach.STDERR < /dev/null &
+pid=$!
+echo "Launched ${cmd}: pid=${pid}"
+# Sleep a bit to let the process start before we terminate the ssh connection.
+sleep 5

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,0 +1,40 @@
+provider "aws" {
+    access_key = "${var.aws_access_key}"
+    secret_key = "${var.aws_secret_key}"
+    region = "${var.aws_region}"
+}
+
+resource "aws_instance" "cockroach" {
+    tags {
+      Name = "${format("cockroach-%d", "${count.index}")}"
+    }
+    ami = "${var.aws_ami_id}"
+    availability_zone = "${var.aws_availability_zone}"
+    instance_type = "t1.micro"
+    security_groups = ["${aws_security_group.default.name}"]
+    key_name = "${var.key_name}"
+    count = "${var.num_instances}"
+
+    connection {
+      user = "ubuntu"
+      key_file = "~/.ssh/${var.key_name}.pem"
+    }
+
+    provisioner "file" {
+        source = "${var.cockroach_binary}"
+        destination = "/home/ubuntu/cockroach"
+    }
+
+    provisioner "file" {
+        source = "launch.sh"
+        destination = "/home/ubuntu/launch.sh"
+    }
+
+   provisioner "remote-exec" {
+        inline = [
+          "chmod 755 launch.sh",
+          "./launch.sh ${var.action} ${var.gossip}",
+          "sleep 1",
+        ]
+   }
+}

--- a/terraform/aws/output.tf
+++ b/terraform/aws/output.tf
@@ -1,0 +1,15 @@
+output "port" {
+  value = "${var.cockroach_port}"
+}
+
+output "elb" {
+  value = "${aws_elb.elb.dns_name}"
+}
+
+output "gossip_variable" {
+  value = "${format("%s:%s", aws_elb.elb.dns_name, var.cockroach_port)}"
+}
+
+output "instances" {
+  value = "${join(",", aws_instance.cockroach.*.public_dns)}"
+}

--- a/terraform/aws/security_group.tf
+++ b/terraform/aws/security_group.tf
@@ -1,0 +1,24 @@
+resource "aws_security_group" "default" {
+  name = "cockroach_security_group"
+
+  ingress {
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = "${var.cockroach_port}"
+    to_port = "${var.cockroach_port}"
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,48 @@
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+
+# Value of the --gossip flag to pass to the backends.
+# This should be populated with the load balancer address.
+# Make sure to populate this before changing num_instances to greater than 0.
+# eg: lb=elb-893485366.us-east-1.elb.amazonaws.com:26257
+variable "gossip" {}
+
+# Number of instances to start.
+variable "num_instances" {}
+
+# Port used for the load balancer and backends.
+variable "cockroach_port" {
+  default = "26257"
+}
+
+# AWS region to use. WARNING: changing this will break the AMI ID.
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+# AWS availability zone. Make sure it exists for your account.
+variable "aws_availability_zone" {
+  default = "us-east-1a"
+}
+
+# AWS image ID. The default is valid for region "us-east-1".
+variable "aws_ami_id" {
+  default = "ami-408c7f28"
+}
+
+# Path to the cockroach binary.
+variable "cockroach_binary" {
+  default = "../../../cockroach/cockroach"
+}
+
+# Name of the ssh key pair for this AWS region. Your .pem file must be:
+# ~/.ssh/<key_name>.pem
+variable "key_name" {
+  default = "cockroach"
+}
+
+# Action is one of "init" or "start". init should only be specified when
+# running `terraform apply` on the first node.
+variable "action" {
+  default = "start"
+}

--- a/terraform/gce/README.md
+++ b/terraform/gce/README.md
@@ -1,0 +1,3 @@
+# Deploy cockroach cluster on Google Cloud using Terraform
+
+***WARNING*** This is currently non-functional due to GCE network load balancing configuration.

--- a/terraform/gce/config.tpl
+++ b/terraform/gce/config.tpl
@@ -1,0 +1,4 @@
+PORT=${var.cockroach_port}
+GOSSIP=${var.gossip}
+LB_ADDRESS=${var.load_balancer_address}
+LOCAL_ADDRESS=${self.network_interface.0.address}

--- a/terraform/gce/launch.sh
+++ b/terraform/gce/launch.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# This is a simple wrapper script around the cockroach binary.
+# It must be in the same directory as the cockroach binary, and invoked in one of two ways:
+#
+# To start the first node and initialize the cluster:
+# ./launch init [load balancer address:port]
+# To start a node:
+# ./launch start [load balancer address:port]
+set -ex
+
+source config.sh
+
+DATA_DIR="data"
+LOG_DIR="logs"
+STORES="ssd=${DATA_DIR}"
+COMMON_FLAGS="--log-dir=${LOG_DIR} --logtostderr=false --stores=${STORES}"
+START_FLAGS="--insecure --addr=${LOCAL_ADDRESS}:${PORT}"
+
+action=$1
+if [ "${action}" != "init" -a "${action}" != "start" ]; then
+  echo "Usage: ${0} [init|start] [load balancer address:port]"
+  exit 1
+fi
+
+# Setup iptables rules.
+sudo iptables -t nat -A PREROUTING -p tcp --dport ${PORT} -j DNAT --to-destination ${LOCAL_ADDRESS}
+sudo iptables -t nat -A POSTROUTING -p tcp -d ${LB_ADDRESS} --dport ${PORT} -j SNAT --to-source ${LOCAL_ADDRESS}
+
+chmod 755 cockroach
+mkdir -p ${DATA_DIR} ${LOG_DIR}
+
+if [ "${action}" == "init" ]; then
+  ./cockroach init ${COMMON_FLAGS}
+fi
+
+cmd="./cockroach start ${COMMON_FLAGS} ${START_FLAGS} --gossip=${GOSSIP}"
+nohup ${cmd} > ${LOG_DIR}/cockroach.STDOUT 2> ${LOG_DIR}/cockroach.STDERR < /dev/null &
+pid=$!
+echo "Launched ${cmd}: pid=${pid}"
+# Sleep a bit to let the process start before we terminate the ssh connection.
+sleep 5

--- a/terraform/gce/main.tf
+++ b/terraform/gce/main.tf
@@ -1,0 +1,61 @@
+provider "google" {
+  region = "${var.gce_region}"
+  project = "${var.gce_project}"
+  account_file = "${file(var.gce_account_file)}"
+}
+
+resource "google_compute_instance" "cockroach" {
+  count = "${var.num_instances}"
+
+  name = "cockroach-${count.index}"
+  machine_type = "n1-standard-1"
+  zone = "${var.gce_zone}"
+  tags = ["cockroach"]
+
+  disk {
+    image = "${var.gce_image}"
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+        # Ephemeral
+    }
+  }
+
+  metadata {
+    sshKeys = "ubuntu:${file("~/.ssh/${var.key_name}.pub")}"
+  }
+
+  connection {
+    user = "ubuntu"
+    key_file = "~/.ssh/${var.key_name}"
+  }
+
+  provisioner "file" {
+    source = "${var.cockroach_binary}"
+    destination = "/home/ubuntu/cockroach"
+  }
+
+  provisioner "file" {
+    source = "launch.sh"
+    destination = "/home/ubuntu/launch.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'PORT=${var.cockroach_port}' > config.sh",
+      "echo 'GOSSIP=${var.gossip}' >> config.sh",
+      "echo 'LB_ADDRESS=${var.load_balancer_address}' >> config.sh",
+      "echo 'LOCAL_ADDRESS=${self.network_interface.0.address}' >> config.sh",
+      "chmod 755 launch.sh config.sh",
+      "./launch.sh ${var.action}",
+      "sleep 1",
+    ]
+  }
+
+  service_account {
+    scopes = ["https://www.googleapis.com/auth/compute.readonly"]
+  }
+}
+

--- a/terraform/gce/network.tf
+++ b/terraform/gce/network.tf
@@ -1,0 +1,37 @@
+resource "google_compute_http_health_check" "default" {
+  name = "cockroach-health-check"
+  request_path = "/"
+  port = "${var.cockroach_port}"
+  check_interval_sec = 2
+  healthy_threshold = 2
+  unhealthy_threshold = 2
+  timeout_sec = 2
+}
+
+resource "google_compute_target_pool" "default" {
+  name = "cockroach-target-pool"
+  # Note: when there are no instances, aws_instance.cockroach.*.id has an empty
+  # element, causing failed elb updates. See: https://github.com/hashicorp/terraform/issues/3581
+  instances = ["${compact(split(",", join(",",google_compute_instance.cockroach.*.self_link)))}"]
+  health_checks = ["${google_compute_http_health_check.default.name}"]
+}
+
+resource "google_compute_forwarding_rule" "default" {
+  name = "cockroach-forwarding-rule"
+  target = "${google_compute_target_pool.default.self_link}"
+  port_range = "${var.cockroach_port}"
+}
+
+resource "google_compute_firewall" "default" {
+  name = "cockroach-firewall"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports = ["${var.cockroach_port}"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags = ["cockroach"]
+}
+

--- a/terraform/gce/output.tf
+++ b/terraform/gce/output.tf
@@ -1,0 +1,15 @@
+output "port" {
+  value = "${var.cockroach_port}"
+}
+
+output "fowarding_rule" {
+  value = "${google_compute_forwarding_rule.default.ip_address}"
+}
+
+output "gossip_variable" {
+  value = "${format("lb=%s:%s", google_compute_forwarding_rule.default.ip_address, var.cockroach_port)}"
+}
+
+output "instances" {
+  value = "${join(",", google_compute_instance.cockroach.*.network_interface.0.access_config.0.nat_ip)}"
+}

--- a/terraform/gce/variables.tf
+++ b/terraform/gce/variables.tf
@@ -1,0 +1,67 @@
+# Port used for the load balancer and backends.
+variable "cockroach_port" {
+  default = "26257"
+}
+
+# GCE region to use.
+variable "gce_region" {
+  default = "us-east1"
+}
+
+# GCE zone to use.
+variable "gce_zone" {
+  default = "us-east1-b"
+}
+
+# GCE project name.
+variable "gce_project" {
+  default = "cockroach-marc"
+}
+
+# GCE account file.
+variable "gce_account_file" {
+  default = "~/terraform/cockroach-marc-64455dfdb138.json"
+}
+
+# GCE image name.
+variable "gce_image" {
+  default = "ubuntu-os-cloud/ubuntu-1510-wily-v20151021"
+}
+
+# Path to the cockroach binary.
+variable "cockroach_binary" {
+  default = "~/cockroach/src/github.com/cockroachdb/cockroach/cockroach"
+}
+
+# Name of the ssh key pair to use for GCE instances.
+# The public key will be passed at instance creation, and the private
+# key will be used by the local ssh client.
+# The path is expanded to: ~/.ssh/<key_name>.pub
+variable "key_name" {
+  default = "gce_cockroach"
+}
+
+# Action is one of "init" or "start". init should only be specified when
+# running `terraform apply` on the first node.
+variable "action" {
+  default = "start"
+}
+
+# Value of the --gossip flag to pass to the backends.
+# This should be populated with the load balancer address.
+# Make sure to populate this before changing num_instances to greater than 0.
+# eg: lb=elb-893485366.us-east-1.elb.amazonaws.com:26257
+variable "gossip" {
+  default = "http-lb=104.196.4.96:26257"
+  #default = ""
+}
+
+variable "load_balancer_address" {
+  default = "104.196.4.96"
+  #default = ""
+}
+
+# Number of instances to start.
+variable "num_instances" {
+  default = 3
+}


### PR DESCRIPTION
Full terraform config and documentation to launch a cluster on AWS.

Full config for GCE, but broken due to the load balancer support
(terraform supports the wrong one).