### PR TITLE
Use daily cockroach binary stored in S3.

### DIFF
--- a/Bunchfile
+++ b/Bunchfile
@@ -25,7 +25,6 @@ golang.org/x/net/context
 golang.org/x/oauth2
 google.golang.org/api/compute/v1
 google.golang.org/api/googleapi
-google.golang.org/api/internal
 google.golang.org/api/resourceviews/v1beta2
 gopkg.in/yaml.v1
 github.com/kisielk/errcheck

--- a/Bunchfile.lock
+++ b/Bunchfile.lock
@@ -29,7 +29,6 @@
     "golang.org/x/tools/cmd/goimports": "823804e1ae08dbb14eb807afc7db9993bc9e3cc3",
     "google.golang.org/api/compute/v1": "c83ee8e9b7e6c40a486c0992a963ea8b6911de67",
     "google.golang.org/api/googleapi": "c83ee8e9b7e6c40a486c0992a963ea8b6911de67",
-    "google.golang.org/api/internal": "c83ee8e9b7e6c40a486c0992a963ea8b6911de67",
     "google.golang.org/api/resourceviews/v1beta2": "c83ee8e9b7e6c40a486c0992a963ea8b6911de67",
     "gopkg.in/yaml.v1": "9f9df34309c04878acc86042b16630b0f696e1de"
 }

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -10,7 +10,6 @@ The following steps will create a three node cluster.
 2. [Download terraform](https://terraform.io/downloads.html), *version 0.6.6 or greater*, unzip, and add to your `PATH`.
 3. [Find your AWS credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html#cli-signup). Save them as environment variables `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`.
 4. [Create an AWS keypair](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:sort=keyName) named `cockroach` and save the file as `~/.ssh/cockroach.pem`.
-5. Check out the [Cockroach repository](https://github.com/cockroachdb/cockroach) and build the cockroach binary. It must be located at `~/cockroach/src/github.com/cockroachdb/cockroach/cockroach` (adjust `cockroach_binary` in `variables.tf` otherwise).
 
 ## Variables
 
@@ -19,7 +18,6 @@ The following variables can be modified in `variables.tf` if necessary.
 * `aws_region`: region to run in. Affects `aws_availability_zone` and `aws_ami_id`
 * `aws_availability_zone`: availability zone for instances and load balancer
 * `aws_ami_id`: image ID. depends on the region.
-* `cockroach_binary`: path to the cockroach binary
 * `key_name`: base name of the AWS key
 * `action`: default action. Defaults to `start`. Override is specified in initialization step
 

--- a/terraform/aws/launch.sh
+++ b/terraform/aws/launch.sh
@@ -8,6 +8,19 @@
 # ./launch start [gossip flag value]
 set -ex
 
+# Lookup name of latest cockroach binary.
+BUCKET_PATH="cockroachdb/bin"
+LATEST="LATEST"
+binary_name=$(curl https://s3.amazonaws.com/${BUCKET_PATH}/${LATEST})
+if [ -z "${binary_name}" ]; then
+  echo "Could not fetch latest cockroach binary"
+fi
+
+# Fetch binary and symlink.
+time curl -O https://s3.amazonaws.com/${BUCKET_PATH}/${binary_name}
+chmod 755 ${binary_name}
+ln -s -f ${binary_name} cockroach
+
 DATA_DIR="data"
 LOG_DIR="logs"
 STORES="ssd=${DATA_DIR}"
@@ -26,7 +39,6 @@ if [ -z "${gossip}" ]; then
   exit 1
 fi
 
-chmod 755 cockroach
 mkdir -p ${DATA_DIR} ${LOG_DIR}
 
 if [ "${action}" == "init" ]; then

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -21,11 +21,6 @@ resource "aws_instance" "cockroach" {
     }
 
     provisioner "file" {
-        source = "${var.cockroach_binary}"
-        destination = "/home/ubuntu/cockroach"
-    }
-
-    provisioner "file" {
         source = "launch.sh"
         destination = "/home/ubuntu/launch.sh"
     }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -30,11 +30,6 @@ variable "aws_ami_id" {
   default = "ami-408c7f28"
 }
 
-# Path to the cockroach binary.
-variable "cockroach_binary" {
-  default = "../../../cockroach/cockroach"
-}
-
 # Name of the ssh key pair for this AWS region. Your .pem file must be:
 # ~/.ssh/<key_name>.pem
 variable "key_name" {


### PR DESCRIPTION
This brings down the time to start instances to ~1.1min.
Ditto to bring X more as terraform parallelizes everything.

This also removes the need for cross-compilation for non-linux folks.