### PR TITLE
Use static binaries for sql.test.

### DIFF
--- a/terraform/aws/examples.tf
+++ b/terraform/aws/examples.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "example_block_writer" {
 
     ami = "${var.aws_ami_id}"
     availability_zone = "${var.aws_availability_zone}"
-    instance_type = "t1.micro"
+    instance_type = "${var.aws_instance_type}"
     security_groups = ["${aws_security_group.default.name}"]
     key_name = "${var.key_name}"
     count = "${var.example_block_writer_instances}"

--- a/terraform/aws/launch.sh
+++ b/terraform/aws/launch.sh
@@ -10,19 +10,22 @@ set -ex
 
 # Lookup name of latest cockroach binary.
 BUCKET_PATH="cockroachdb/bin"
-LATEST="LATEST"
-binary_name=$(curl https://s3.amazonaws.com/${BUCKET_PATH}/${LATEST})
+LATEST_SUFFIX=".LATEST"
+LOG_DIR="logs"
+
+BINARY="cockroach"
+
+binary_name=$(curl https://s3.amazonaws.com/${BUCKET_PATH}/${BINARY}${LATEST_SUFFIX})
 if [ -z "${binary_name}" ]; then
-  echo "Could not fetch latest cockroach binary"
+  echo "Could not fetch latest binary"
 fi
 
 # Fetch binary and symlink.
 time curl -O https://s3.amazonaws.com/${BUCKET_PATH}/${binary_name}
 chmod 755 ${binary_name}
-ln -s -f ${binary_name} cockroach
+ln -s -f ${binary_name} ${BINARY}
 
 DATA_DIR="data"
-LOG_DIR="logs"
 STORES="ssd=${DATA_DIR}"
 COMMON_FLAGS="--log-dir=${LOG_DIR} --logtostderr=false --stores=${STORES}"
 START_FLAGS="--insecure"

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -10,7 +10,7 @@ resource "aws_instance" "cockroach" {
     }
     ami = "${var.aws_ami_id}"
     availability_zone = "${var.aws_availability_zone}"
-    instance_type = "t1.micro"
+    instance_type = "${var.aws_instance_type}"
     security_groups = ["${aws_security_group.default.name}"]
     key_name = "${var.key_name}"
     count = "${var.num_instances}"

--- a/terraform/aws/tests/launch.sh
+++ b/terraform/aws/tests/launch.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This is a simple wrapper script to download and run sql.test.
+set -ex
+
+# Lookup name of latest cockroach binary.
+BUCKET_PATH="cockroachdb/bin"
+LATEST_SUFFIX=".LATEST"
+LOG_DIR="logs"
+
+BINARY="sql.test"
+FLAGS="--test.run=TestLogic -d test/index/*/*/*.test"
+
+binary_name=$(curl https://s3.amazonaws.com/${BUCKET_PATH}/${BINARY}${LATEST_SUFFIX})
+if [ -z "${binary_name}" ]; then
+  echo "Could not fetch latest binary"
+fi
+
+# Fetch binary and symlink.
+time curl -O https://s3.amazonaws.com/${BUCKET_PATH}/${binary_name}
+chmod 755 ${binary_name}
+ln -s -f ${binary_name} ${BINARY}
+
+mkdir -p ${LOG_DIR}
+
+cmd="./${BINARY} ${FLAGS}"
+nohup ${cmd} > ${LOG_DIR}/${BINARY}.STDOUT 2> ${LOG_DIR}/${BINARY}.STDERR < /dev/null &
+pid=$!
+echo "Launched ${cmd}: pid=${pid}"
+# Sleep a bit to let the process start before we terminate the ssh connection.
+sleep 5

--- a/terraform/aws/tests/variables.tf
+++ b/terraform/aws/tests/variables.tf
@@ -1,11 +1,6 @@
 variable "aws_access_key" {}
 variable "aws_secret_key" {}
 
-# Path to the cockroach repository.
-variable "cockroach_repo" {
-  default = "../../../../cockroach"
-}
-
 # Path to the sqllogictest repository.
 variable "sqllogictest_repo" {
   default = "../../../../sqllogictest"
@@ -27,8 +22,14 @@ variable "aws_availability_zone" {
 }
 
 # AWS image ID. The default is valid for region "us-east-1".
+# This is an ubuntu image with HVM.
 variable "aws_ami_id" {
-  default = "ami-408c7f28"
+  default = "ami-1c552a76"
+}
+
+# AWS instance type. This may affect valid AMIs.
+variable "aws_instance_type" {
+  default = "t2.medium"
 }
 
 # Name of the ssh key pair for this AWS region. Your .pem file must be:

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -26,8 +26,14 @@ variable "aws_availability_zone" {
 }
 
 # AWS image ID. The default is valid for region "us-east-1".
+# This is an ubuntu image with HVM.
 variable "aws_ami_id" {
-  default = "ami-408c7f28"
+  default = "ami-1c552a76"
+}
+
+# AWS instance type. This may affect valid AMIs.
+variable "aws_instance_type" {
+  default = "t2.micro"
 }
 
 # Name of the ssh key pair for this AWS region. Your .pem file must be:


### PR DESCRIPTION
Other:
* handle new name for the cockroach binary
* tweak instance types (impacts AMI ID as well)