### PR TITLE
Simply credentials usage for terraform.

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -8,7 +8,7 @@ The following steps will create a three node cluster.
 ## One-time setup steps
 1. Have an [AWS](http://aws.amazon.com/) account
 2. [Download terraform](https://terraform.io/downloads.html), *version 0.6.6 or greater*, unzip, and add to your `PATH`.
-3. [Find your AWS credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html#cli-signup). Save them as environment variables `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`.
+3. [Valid AWS credentials file](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html#cli-signup).
 4. [Create an AWS keypair](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:sort=keyName) named `cockroach` and save the file as `~/.ssh/cockroach.pem`.
 
 ## Variables
@@ -33,8 +33,6 @@ To see the actions expected to be performed by terraform, use `plan` instead of 
 
 ```
 $ terraform apply \
-    --var=aws_access_key="${AWS_ACCESS_KEY}" \
-    --var=aws_secret_key="${AWS_SECRET_KEY}" \
     --var=gossip=""                       \
     --var=num_instances=0
 
@@ -62,8 +60,6 @@ $ export ELB="elb-1289187553.us-east-1.elb.amazonaws.com:26257"
 
 ```
 $ terraform apply \
-    --var=aws_access_key="${AWS_ACCESS_KEY}" \
-    --var=aws_secret_key="${AWS_SECRET_KEY}" \
     --var=gossip="lb=${ELB}" \
     --var=num_instances=1                 \
     --var=action="init"
@@ -92,8 +88,6 @@ The cluster is now running with a single node and is reachable through the load 
 
 ```
 $ terraform apply \
-    --var=aws_access_key="${AWS_ACCESS_KEY}" \
-    --var=aws_secret_key="${AWS_SECRET_KEY}" \
     --var=gossip="lb=${ELB}" \
     --var=num_instances=3
 
@@ -173,8 +167,6 @@ See `examples.tf` for sample examples and how to run them against the created cl
 
 ```
 $ terraform destroy \
-    --var=aws_access_key="${AWS_ACCESS_KEY}" \
-    --var=aws_secret_key="${AWS_SECRET_KEY}" \
     --var=gossip="lb=${ELB}" \
     --var=num_instances=3
 ```

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,12 +1,10 @@
 provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
     region = "${var.aws_region}"
 }
 
 resource "aws_instance" "cockroach" {
     tags {
-      Name = "${format("cockroach-%d", "${count.index}")}"
+        Name = "${format("cockroach-%d", "${count.index}")}"
     }
     ami = "${var.aws_ami_id}"
     availability_zone = "${var.aws_availability_zone}"
@@ -16,8 +14,8 @@ resource "aws_instance" "cockroach" {
     count = "${var.num_instances}"
 
     connection {
-      user = "ubuntu"
-      key_file = "~/.ssh/${var.key_name}.pem"
+        user = "ubuntu"
+        key_file = "~/.ssh/${var.key_name}.pem"
     }
 
     provisioner "file" {

--- a/terraform/aws/tests/launch.sh
+++ b/terraform/aws/tests/launch.sh
@@ -23,8 +23,7 @@ ln -s -f ${binary_name} ${BINARY}
 mkdir -p ${LOG_DIR}
 
 cmd="./${BINARY} ${FLAGS}"
-nohup ${cmd} > ${LOG_DIR}/${BINARY}.STDOUT 2> ${LOG_DIR}/${BINARY}.STDERR < /dev/null &
-pid=$!
-echo "Launched ${cmd}: pid=${pid}"
-# Sleep a bit to let the process start before we terminate the ssh connection.
-sleep 5
+time ${cmd} > ${LOG_DIR}/${BINARY}.STDOUT 2> ${LOG_DIR}/${BINARY}.STDERR < /dev/null
+# SECONDS is the time since the shell started. This is a good approximation for now,
+# more details are in the output.
+echo ${SECONDS} > ${LOG_DIR}/DONE

--- a/terraform/aws/tests/main.tf
+++ b/terraform/aws/tests/main.tf
@@ -56,9 +56,11 @@ resource "aws_instance" "sql_logic_test" {
    provisioner "remote-exec" {
         inline = [
           "chmod 755 launch.sh",
+          "rm -rf logs",
+          "mkdir -p logs",
           "tar xfz sqltests.tgz",
-          "./launch.sh",
-          "sleep 1",
+          "nohup ./launch.sh > logs/nohup.out < /dev/null &",
+          "sleep 5",
         ]
    }
 }

--- a/terraform/aws/tests/main.tf
+++ b/terraform/aws/tests/main.tf
@@ -1,15 +1,13 @@
 # Run the sql logic test suite on AWS.
 # Prerequisites:
-# - AWS account credentials and key as specified in cockroach-prod/terraform/aws/README.md
+# - AWS account credentials file as specified in cockroach-prod/terraform/aws/README.md
 # - sqllogic test repo cloned
 #
 # Run with:
-# terraform apply --var=aws_access_key="${AWS_ACCESS_KEY}" \
-#                 --var=aws_secret_key="${AWS_SECRET_KEY}"
+# $ terraform apply
 #
 # Tear down AWS resources using:
-# terraform destroy --var=aws_access_key="${AWS_ACCESS_KEY}" \
-#                   --var=aws_secret_key="${AWS_SECRET_KEY}"
+# $ terraform destroy
 #
 # The used logic tests are tarred and gzipped before launching the instance.
 # Test are sharded by subdirectory (see variables.tf for details), with one
@@ -20,18 +18,16 @@
 # $ ssh -i ~/.ssh/cockroach.pem ubuntu@<instance> tail -F test.STDOUT
 
 provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
     region = "${var.aws_region}"
 }
 
 output "instance" {
-  value = "${join(",", aws_instance.sql_logic_test.*.public_dns)}"
+    value = "${join(",", aws_instance.sql_logic_test.*.public_dns)}"
 }
 
 resource "aws_instance" "sql_logic_test" {
     tags {
-      Name = "cockroach-sql-logic-test-${count.index}"
+        Name = "cockroach-sql-logic-test-${count.index}"
     }
     depends_on = ["null_resource.sql_tarball"]
 

--- a/terraform/aws/tests/variables.tf
+++ b/terraform/aws/tests/variables.tf
@@ -1,6 +1,3 @@
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-
 # Path to the sqllogictest repository.
 variable "sqllogictest_repo" {
   default = "../../../../sqllogictest"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,6 +1,3 @@
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-
 # Value of the --gossip flag to pass to the backends.
 # This should be populated with the load balancer address.
 # Make sure to populate this before changing num_instances to greater than 0.


### PR DESCRIPTION
Turns out the AWS libraries used by terraform are happy with a standard
credentials file, so we can remove a lot of extra flags.