### PR TITLE
Simplify cluster setup.

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -23,93 +23,35 @@ The following variables can be modified in `variables.tf` if necessary.
 
 ## Create the cluster
 
-The following three commands will initialize all needed AWS infrastructure in the region `us-east-1`,
+The following two commands will initialize all needed AWS infrastructure in the region `us-east-1`,
 initialize the first cockroach node, then add two more nodes to the cluster.
 All dynamic configuration is set through terraform command-line flags but can be set in `variables.tf`.
 
 To see the actions expected to be performed by terraform, use `plan` instead of `apply`.
 
-#### Initialize AWS infrastructure
+#### Initialize AWS infrastructure and first node
 
 ```
-$ terraform apply \
-    --var=gossip=""                       \
-    --var=num_instances=0
+$ terraform apply --var=num_instances=1 --var=action="init"
 
-aws_security_group.default: Creating...
-aws_security_group.default: Creation complete
-aws_elb.elb: Creating...
-aws_elb.elb: Creation complete
 Outputs:
-  elb             = elb-1289187553.us-east-1.elb.amazonaws.com
-  gossip_variable = elb-1289187553.us-east-1.elb.amazonaws.com:26257
-  instances       = 
-  port            = 26257
-
+  elb_address          = elb-1371418843.us-east-1.elb.amazonaws.com:26257
+  example_block_writer =
+  instances            = ec2-54-152-252-37.compute-1.amazonaws.com
 ```
 
-This command creates a load balancer and displays the value of the gossip flag to be used in the
-following steps.
-
-Save the elb address and port as an environment variable:
-```
-$ export ELB="elb-1289187553.us-east-1.elb.amazonaws.com:26257"
-```
-
-#### Initialize the first node
-
-```
-$ terraform apply \
-    --var=gossip="lb=${ELB}" \
-    --var=num_instances=1                 \
-    --var=action="init"
-
-aws_security_group.default: Refreshing state... (ID: sg-828435e4)
-aws_elb.elb: Refreshing state... (ID: elb)
-aws_instance.cockroach: Creating...
-aws_instance.cockroach: Provisioning with 'file'...
-aws_instance.cockroach: Provisioning with 'file'...
-aws_instance.cockroach: Provisioning with 'remote-exec'...
-aws_instance.cockroach: Creation complete
-aws_elb.elb: Modifying...
-aws_elb.elb: Modifications complete
-Outputs:
-  elb             = elb-1289187553.us-east-1.elb.amazonaws.com
-  gossip_variable = elb-1289187553.us-east-1.elb.amazonaws.com:26257
-  instances       = ec2-54-85-12-159.compute-1.amazonaws.com
-  port            = 26257
-
-```
-
-The `--var=action="init"` parameter causes the first node to be initialized for with a new cluster.
-The cluster is now running with a single node and is reachable through the load balancer (see `Using the cluster`).
+The `--var=action="init"` parameter causes the first node to be initialized for a new cluster.
+The cluster is now running with a single node and is reachable through the `elb_address` (see `Using the cluster`).
 
 #### Add more nodes to the cluster
 
 ```
-$ terraform apply \
-    --var=gossip="lb=${ELB}" \
-    --var=num_instances=3
+$ terraform apply --var=num_instances=3
 
-aws_security_group.default: Refreshing state... (ID: sg-828435e4)
-aws_instance.cockroach.0: Refreshing state... (ID: i-1d10fbca)
-aws_elb.elb: Refreshing state... (ID: elb)
-aws_instance.cockroach.1: Creating...
-aws_instance.cockroach.2: Creating...
-aws_instance.cockroach.2: Provisioning with 'file'...
-aws_instance.cockroach.1: Provisioning with 'file'...
-aws_instance.cockroach.2: Provisioning with 'remote-exec'...
-aws_instance.cockroach.2: Creation complete
-aws_instance.cockroach.1: Provisioning with 'remote-exec'...
-aws_instance.cockroach.1: Creation complete
-aws_elb.elb: Modifying...
-aws_elb.elb: Modifications complete
 Outputs:
-  elb             = elb-1289187553.us-east-1.elb.amazonaws.com
-  gossip_variable = elb-1289187553.us-east-1.elb.amazonaws.com:26257
-  instances       = ec2-54-85-12-159.compute-1.amazonaws.com,ec2-54-175-192-198.compute-1.amazonaws.com,ec2-54-88-84-13.compute-1.amazonaws.com
-  port            = 26257
-
+  elb_address          = elb-1371418843.us-east-1.elb.amazonaws.com:26257
+  example_block_writer =
+  instances            = ec2-54-152-252-37.compute-1.amazonaws.com,ec2-54-175-103-126.compute-1.amazonaws.com,ec2-54-175-166-150.compute-1.amazonaws.com
 ```
 
 ## Use the cluster
@@ -120,7 +62,7 @@ Use the load balancer address to connect to the cluster. You may need to wait a 
 ELB creation for its DNS name to be resolvable.
 
 ```
-$ ./cockroach sql --insecure --addr=${ELB}
+$ ./cockroach sql --insecure --addr=<elb_address from terraform output>
 elb-1289187553.us-east-1.elb.amazonaws.com:26257> show databases;
 +----------+
 | Database |
@@ -137,7 +79,7 @@ The DNS names of AWS instances is shown as a comma-separated list in the terrafo
 $ ssh -i ~/.ssh/cockroach.pem ubuntu@ec2-54-85-12-159.compute-1.amazonaws.com
 
 ubuntu@ip-172-31-15-87:~$ ps -Af|grep cockroach
-ubuntu    1448     1  4 20:03 ?        00:00:39 ./cockroach start --log-dir=logs --logtostderr=false --stores=ssd=data --insecure --gossip=lb=${ELB}
+ubuntu    1448     1  4 20:03 ?        00:00:39 ./cockroach start --log-dir=logs --logtostderr=false --stores=ssd=data --insecure --gossip=lb=elb-1289187553.us-east-1.elb.amazonaws.com:26257
 
 ubuntu@ip-172-31-15-87:~$ ls logs
 cockroach.ERROR
@@ -164,33 +106,18 @@ $ go tool pprof <address:port>/debug/pprof/profile
 See `examples.tf` for sample examples and how to run them against the created cluster.
 The `block_writer` can be run against the newly-created cluster by running:
 ```
-$ terraform apply \
-    --var=gossip="lb=${ELB}" \
-    --var=num_instances=3    \
-    --var=example_block_writer_instances=1
+$ terraform apply --var=num_instances=3 --var=example_block_writer_instances=1
 
-aws_security_group.default: Refreshing state... (ID: sg-151a7473)
-aws_instance.cockroach.0: Refreshing state... (ID: i-37ca4d87)
-aws_instance.cockroach.1: Refreshing state... (ID: i-b8d15608)
-aws_instance.cockroach.2: Refreshing state... (ID: i-5ed255ee)
-aws_elb.elb: Refreshing state... (ID: elb)
-aws_instance.example_block_writer: Creating...
-aws_instance.example_block_writer: Provisioning with 'file'...
-aws_instance.example_block_writer: Provisioning with 'remote-exec'...
 Outputs:
-  elb                  = elb-1693783722.us-east-1.elb.amazonaws.com
+  elb_address          = elb-1371418843.us-east-1.elb.amazonaws.com:26257
   example_block_writer = ec2-54-175-206-76.compute-1.amazonaws.com
-  gossip_variable      = elb-1693783722.us-east-1.elb.amazonaws.com:26257
-  instances            = ec2-54-152-242-91.compute-1.amazonaws.com,ec2-54-152-233-87.compute-1.amazonaws.com,ec2-54-152-138-254.compute-1.amazonaws.com
-  port                 = 26257
+  instances            = ec2-54-152-252-37.compute-1.amazonaws.com,ec2-54-175-103-126.compute-1.amazonaws.com,ec2-54-175-166-150.compute-1.amazonaws.com
 ```
 
 ## Destroy the cluster
 
 ```
-$ terraform destroy \
-    --var=gossip="lb=${ELB}" \
-    --var=num_instances=3
+$ terraform destroy --var=num_instances=3
 ```
 
 The destroy command requires confirmation.

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -12,10 +12,18 @@ resource "aws_instance" "cockroach" {
   security_groups = ["${aws_security_group.default.name}"]
   key_name = "${var.key_name}"
   count = "${var.num_instances}"
+}
 
+# We use a null_resource to break the dependency cycle
+# between aws_elb and aws_instance.
+# This can be rolled back into aws_instance when https://github.com/hashicorp/terraform/issues/3999
+# is addressed.
+resource "null_resource" "cockroach-provisioner" {
+  count = "${var.num_instances}"
   connection {
     user = "ubuntu"
     key_file = "~/.ssh/${var.key_name}.pem"
+    host = "${element(aws_instance.cockroach.*.public_ip, count.index)}"
   }
 
   provisioner "file" {
@@ -32,7 +40,7 @@ resource "aws_instance" "cockroach" {
     inline = [
       "bash download_binary.sh cockroach",
       "chmod 755 launch.sh",
-      "./launch.sh ${var.action} ${var.gossip}",
+      "./launch.sh ${var.action} ${aws_elb.elb.dns_name}:${var.cockroach_port}",
       "sleep 1",
     ]
   }

--- a/terraform/aws/output.tf
+++ b/terraform/aws/output.tf
@@ -1,12 +1,4 @@
-output "port" {
-  value = "${var.cockroach_port}"
-}
-
-output "elb" {
-  value = "${aws_elb.elb.dns_name}"
-}
-
-output "gossip_variable" {
+output "elb_address" {
   value = "${format("%s:%s", aws_elb.elb.dns_name, var.cockroach_port)}"
 }
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,9 +1,3 @@
-# Value of the --gossip flag to pass to the backends.
-# This should be populated with the load balancer address.
-# Make sure to populate this before changing num_instances to greater than 0.
-# eg: lb=elb-893485366.us-east-1.elb.amazonaws.com:26257
-variable "gossip" {}
-
 # Number of instances to start.
 variable "num_instances" {}
 


### PR DESCRIPTION
Reduce number of steps to bring up a full cluster to 2:
* init aws infrastructure and first node
* add more nodes

We can do this by using a null resource to break the circular dependency
between aws_instance and aws_elb.