### PR TITLE
Change default zone and up stop time.

### DIFF
--- a/terraform/aws/supervisor.conf.tpl
+++ b/terraform/aws/supervisor.conf.tpl
@@ -28,7 +28,7 @@ autostart=false
 autorestart=false
 startsecs=2
 startretries=0
-stopwaitsecs=60
+stopwaitsecs=90
 stderr_logfile=%(here)s/logs/%(program_name)s.stderr
 stdout_logfile=%(here)s/logs/%(program_name)s.stdout
 

--- a/terraform/aws/tests/variables.tf
+++ b/terraform/aws/tests/variables.tf
@@ -20,7 +20,7 @@ variable "aws_region" {
 
 # AWS availability zone. Make sure it exists for your account.
 variable "aws_availability_zone" {
-  default = "us-east-1a"
+  default = "us-east-1b"
 }
 
 # AWS image ID. The default is valid for region "us-east-1".


### PR DESCRIPTION
* our new shared user doesn't have us-east-1a, use 1b instead. Readme was updated earlier to point out the likely change to zone
* up stop time on nodes. cockroach aborts draining after 1min, so give it time to stop on its own.