### PR TITLE
More verbose logic_test

### DIFF
--- a/scripts/run_logictests.sh
+++ b/scripts/run_logictests.sh
@@ -116,8 +116,8 @@ cd "${LOGS_DIR}/${run_timestamp}"
 attach_args="--content-type=text/plain"
 binary=$(cat */BINARY|sort|uniq|xargs)
 for i in ${instances}; do
-  ln -s ${i}/sql.test.stdout ${i}.stdout
-  ln -s ${i}/sql.test.stderr ${i}.stderr
+  tail -n 10000 ${i}/sql.test.stdout > ${i}.stdout
+  tail -n 10000 ${i}/sql.test.stderr > ${i}.stderr
   attach_args="${attach_args} -A ${i}.stdout -A ${i}.stderr"
 done
 

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -11,7 +11,7 @@ For multi-user cooperation, please see [Terraform's documentation on remote stat
 1. Have an [AWS](http://aws.amazon.com/) account
 2. [Download terraform](https://terraform.io/downloads.html), *version 0.6.7 or greater*, unzip, and add to your `PATH`.
 3. [Valid AWS credentials file](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html#cli-signup).
-4. [Create an AWS keypair](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:sort=keyName) named `cockroach` and save the file as `~/.ssh/cockroach.pem`. If sharing an account with other users, you may want to customize the key name (eg: keyname=`cockroach-<myusername>`, filename=`~/.ssh/cockroach-<myusername>.pem`) and modify the variable as mentioned in the next section.
+4. [Create an AWS keypair](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:sort=keyName) named `cockroach` and save the file as `~/.ssh/cockroach.pem`. If sharing an account with other users, you may want to customize the key name (eg: key_name:`cockroach-<myusername>`, key path:`~/.ssh/cockroach-<myusername>.pem`) and modify the variable as mentioned in the next section.
 
 ## Variables
 

--- a/terraform/aws/tests/supervisor.conf
+++ b/terraform/aws/tests/supervisor.conf
@@ -18,7 +18,7 @@ serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
 
 [program:sql.test]
 directory=%(here)s
-command=%(here)s/sql.test --test.run=TestLogic --test.timeout=2h -d "test/index/*/*/*.test"
+command=%(here)s/sql.test --test.run=TestLogic --test.timeout=2h --vmodule=logic_test=1 -d "test/index/*/*/*.test"
 process_name=%(program_name)s
 numprocs=1
 autostart=false


### PR DESCRIPTION
vmodule=logic_test=1 will soon log all executed statements and queries.
Limit stdout/stderr to the last 10K lines to avoid breaking email size
limits.