### PR TITLE
Add trigger on runner resource.

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -34,6 +34,10 @@ resource "null_resource" "cockroach-runner" {
     host = "${element(aws_instance.cockroach.*.public_ip, count.index)}"
   }
 
+  triggers {
+    instance_ids = "${element(aws_instance.cockroach.*.id, count.index)}"
+  }
+
   provisioner "file" {
     source = "download_binary.sh"
     destination = "/home/ubuntu/download_binary.sh"


### PR DESCRIPTION
Fixes #60

When terminating an instance and re-running terraform apply,
this will force the runner null_resource to run again.

There is an issue where all runners are triggered, but the ones that
have run before fail.