### PR TITLE
basic framework for automated cluster tests

### DIFF
--- a/scripts/run_cluster.sh
+++ b/scripts/run_cluster.sh
@@ -1,150 +1,59 @@
 #!/bin/bash
 #
-# This script performs the following:
-# - start a cockroach cluster in AWS with TOTAL_INSTANCES instances
-# - start an instance running the block_writer example
-# - wait WAIT_TIME
-# - shut down all AWS jobs
-# TODO(marc): grab logs and send summary email.
-#
-# If run as a cron job, make sure you set your basic environment variables.
-# Run with:
-# run_logictests.sh [log dir]
-#
-# Logs will be saved in [log dir]/date-time/[instance number]/
-#
+# A thin wrapper around the `terrafarm` test runner.
 # Requirements for this to work:
-# * basic environment variables set: HOME, PATH, GOPATH
+# * working Go environment: GOPATH (but possibly HOME, PATH, GOPATH, GOROOT)
 # * ~/.aws/credentials with valid AWS credentials
-# * ~/.ssh/cockroach.pem downloaded from AWS.
+# * ~/.ssh/${KEY_NAME}.pem downloaded from AWS.
 # * terraform installed in your PATH
-# * <COCKROACH_BASE>/cockroach-prod repo cloned and up to date
-# * <COCKROACH_BASE>/cockroach-prod/tools/supervisor/supervisor tool compiled
-# * EC2 keypair under ~/.ssh/cockroach-${USER}.pem
-#
-# This script retries various operations quite a bit, but without
-# a limit on the number of retries. This may cause issues.
+# * for mailing the results to work: Linux.
 #
 # A sample crontab (to be filled-in) to run this nightly would be:
 # MAILTO=myaddress@myprovider.com
-# USER=MYUSER
+# KEY_NAME=cockroach-craig
 # HOME=/home/MYUSER
 # PATH=/bin:/sbin:/usr/bin:/usr/bin:/usr/local/bin:/usr/local/sbin:/home/MYUSER/bin:/home/MYUSER/go/bin
 # GOPATH=/home/MYUSER/cockroach
 #
-# 0 0 * * * /home/MYUSER/cockroach/src/github.com/cockroachdb/cockroach-prod/scripts/run_cluster.sh /MYLOGDIR/ > /MYLOGDIR/LATEST 2>&1
+# 0 0 * * * /home/MYUSER/cockroach/src/github.com/cockroachdb/cockroach-prod/scripts/run_cluster.sh
 
-set -x
+set -eu
 
-source $(dirname $0)/utils.sh
+LOGS_DIR="${1-$(mktemp -d)}"
+KEY_NAME="${KEY_NAME}" # no default, want to crash if not supplied
+MAILTO="${MAILTO-}"
 
-COCKROACH_BASE="${GOPATH}/src/github.com/cockroachdb"
-PROD_REPO="${COCKROACH_BASE}/cockroach-prod"
-LOGS_DIR=$1
-KEY_NAME="cockroach-${USER}"
-SSH_KEY="~/.ssh/${KEY_NAME}.pem"
-SSH_USER="ubuntu"
-TOTAL_INSTANCES=5
-WAIT_TIME=3600
-COCKROACH_BINARY_PATH="cockroach/cockroach"
-BLOCK_WRITER_BINARY_PATH="examples-go/block_writer"
+mkdir -p "${LOGS_DIR}"
 
-if [ -z "${LOGS_DIR}" ]; then
-  echo "No logs directory specified. Run with: $0 [logs dir]"
-  exit 1
-fi
+function finish() {
+  [[ $? -eq 0 ]] && STATUS="OK" || STATUS="FAIL"
+  set +e
 
-if [ -z "${PROD_REPO}" ]; then
-  echo "Could not find directory ${PROD_REPO}"
-  exit 1
-fi
+  cd "${LOGS_DIR}"
+  pwd
 
-which terraform > /dev/null
-if [ $? -ne "0" ]; then
-  echo "Could not find terraform in your path"
-  exit 1
-fi
-
-monitor="${PROD_REPO}/tools/supervisor/supervisor"
-if [ ! -e "${monitor}" ]; then
-  echo "Could not locate supervisor monitor at ${monitor}"
-  exit 1
-fi
-
-cockroach_sha=$(latest_sha ${COCKROACH_BINARY_PATH})
-block_writer_sha=$(latest_sha ${BLOCK_WRITER_BINARY_PATH})
-
-run_timestamp=$(date  +"%Y-%m-%d-%H:%M:%S")
-cd "${PROD_REPO}/terraform/aws"
-
-# Initialize infrastructure and first instance.
-# We loop to retry instances that take too long to setup (it seems to happen).
-do_retry "terraform apply --var=key_name=${KEY_NAME} --var=num_instances=${TOTAL_INSTANCES} --var=cockroach_sha=${cockroach_sha} --var=block_writer_sha=${block_writer_sha}" 5 5
-if [ $? -ne 0 ]; then
-  echo "Terraform apply failed."
-  return 1
-fi
-
-# Fetch instances names.
-instances=$(terraform output instances|tr ',' ' ')
-supervisor_hosts=$(echo ${instances}|fmt -1|awk '{print $1 ":9001"}'|xargs|tr ' ' ',')
-
-# Start the block_writer.
-do_retry "terraform apply --var=key_name=${KEY_NAME} --var=num_instances=${TOTAL_INSTANCES} --var=example_block_writer_instances=1 --var=cockroach_sha=${cockroach_sha} --var=block_writer_sha=${block_writer_sha}" 5 5
-if [ $? -ne 0 ]; then
-  echo "Terraform apply failed."
-  return 1
-fi
-
-# Fetch block writer instances.
-block_writer_instance=$(terraform output example_block_writer)
-
-# Sleep for a while.
-sleep ${WAIT_TIME}
-
-# Stop all processes through supervisor.
-# TODO(marc): switch to --signal when supported (supervisor 3.2.0).
-summary_block_writer=$(${monitor} --program=block_writer --stop --addrs=${block_writer_instance}:9001)
-summary_nodes=$(${monitor} --program=cockroach --stop --addrs=${supervisor_hosts})
-
-# Fetch all logs.
-mkdir -p "${LOGS_DIR}/${run_timestamp}"
-for i in ${instances}; do
-  scp -C -i ${SSH_KEY} -r -oStrictHostKeyChecking=no ${SSH_USER}@${i}:logs "${LOGS_DIR}/${run_timestamp}/node.${i}"
-  if [ $? -ne 0 ]; then
-    echo "Failed to fetch logs from ${i}"
+  if [ -z "${MAILTO}" ]; then
+    echo "MAILTO variable not set, not sending email."
+    return
   fi
-done
 
-scp -C -i ${SSH_KEY} -r -oStrictHostKeyChecking=no ${SSH_USER}@${block_writer_instance}:logs "${LOGS_DIR}/${run_timestamp}/block_writer.${block_writer_instance}"
+  # Generate message and attach logs for each instance.
+  attach_args="--content-type=text/plain"
+  for i in $(seq 0 4); do
+    tail -n 10000 node.${i}/cockroach.stderr > node.${i}.stderr
+    tail -n 10000 node.${i}/cockroach.stdout > node.${i}.stdout
+    tail -n 10000 writer.${i}/block_writer.stderr > block_writer.stderr
+    tail -n 10000 writer.${i}/block_writer.stdout > block_writer.stdout
+    attach_args="${attach_args} -A node.${i}.stderr -A node.${i}.stdout"
+    attach_args="${attach_args} -A writer.${i}.stderr -A writer.${i}.stdout"
+  done
 
-# Destroy all instances.
-do_retry "terraform destroy --force --var=key_name=${KEY_NAME} --var=num_instances=${TOTAL_INSTANCES}" 5 5
+  mail ${attach_args} -s "[${STATUS}] nightly cluster test" "${MAILTO}" < test.txt
+}
 
-# Send email.
-if [ -z "${MAILTO}" ]; then
-  echo "MAILTO variable not set, not sending email."
-  exit 0
-fi
+trap finish EXIT
 
-cd "${LOGS_DIR}/${run_timestamp}"
-
-# Generate message and attach logs for each instance.
-attach_args="--content-type=text/plain"
-for i in ${instances}; do
-  tail -n 10000 node.${i}/cockroach.stderr > node.${i}.stderr
-  tail -n 10000 node.${i}/cockroach.stdout > node.${i}.stdout
-  attach_args="${attach_args} -A node.${i}.stderr -A node.${i}.stdout"
-done
-
-# Attach block writer logs.
-tail -n 10000 block_writer.${block_writer_instance}/block_writer.stderr > block_writer.stderr
-tail -n 10000 block_writer.${block_writer_instance}/block_writer.stdout > block_writer.stdout
-attach_args="${attach_args} -A block_writer.stderr -A block_writer.stdout"
-
-binary_sha_link ${COCKROACH_BINARY_PATH} ${cockroach_sha} > summary.txt
-echo "${summary_nodes}" >> summary.txt
-echo "" >> summary.txt
-binary_sha_link ${BLOCK_WRITER_BINARY_PATH} ${block_writer_sha} >> summary.txt
-echo "${summary_block_writer}" >> summary.txt
-mail ${attach_args} -s "Cluster test ${run_timestamp}" ${MAILTO} < summary.txt
+exec go test -v -timeout 24h -run FiveNodesAndWriters \
+  github.com/cockroachdb/cockroach-prod/tools/terrafarm \
+  -d 1h -key-name "${KEY_NAME}" -l "${LOGS_DIR}" 2>&1 \
+  | tee "${LOGS_DIR}/test.txt"

--- a/tools/terrafarm/main_test.go
+++ b/tools/terrafarm/main_test.go
@@ -1,0 +1,82 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package terrafarm_test // intentionally; prevents access to internals
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach-prod/tools/terrafarm"
+)
+
+var cwd = flag.String("cwd", func() string {
+	const relPath = "../../terraform/aws"
+	absPath, err := filepath.Abs(relPath)
+	if err != nil {
+		return relPath
+	}
+	return absPath
+}(), "directory to run terraform from")
+var keyName = flag.String("key-name", "cockroach", "name of key for cluster")
+var logDir = flag.String("l", "", "log dir (empty for temporary)")
+
+func farmer(t *testing.T) *terrafarm.Farmer {
+	logDir := *logDir
+	if logDir == "" {
+		var err error
+		logDir, err = ioutil.TempDir(os.TempDir(), "clustertest_")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	f := &terrafarm.Farmer{
+		Debug:   true,
+		Cwd:     *cwd,
+		LogDir:  logDir,
+		KeyName: *keyName,
+	}
+	return f
+}
+
+// TestBuildCluster resizes the cluster to one node, one writer.
+// It does not tear down the cluster after it's done and is mostly
+// useful for testing code changes in the `terrafarm` package.
+func TestBuildCluster(t *testing.T) {
+	f := farmer(t)
+	defer f.CollectLogs()
+	if err := f.Resize(1, 1); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestFiveNodesAndWriters runs a five node cluster and five writers.
+// The test runs until SIGINT is received (or the test times out).
+func TestFiveNodesAndWriters(t *testing.T) {
+	f := farmer(t)
+	defer f.MustDestroy()
+	if err := f.Resize(5, 5); err != nil {
+		t.Fatal(err)
+	}
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	<-c
+}

--- a/tools/terrafarm/run.go
+++ b/tools/terrafarm/run.go
@@ -110,6 +110,7 @@ func (f *Farmer) output(key string) []string {
 	return strings.Split(o, ",")
 }
 
-func (f *Farmer) execSupervisor(i int, action string) error {
-	return f.Exec(i, "supervisorctl -c supervisor.conf "+action)
+func (f *Farmer) execSupervisor(host string, action string) (string, string, error) {
+	cmd := "supervisorctl -c supervisor.conf " + action
+	return f.ssh(host, f.defaultKeyFile(), cmd)
 }

--- a/tools/terrafarm/run.go
+++ b/tools/terrafarm/run.go
@@ -93,7 +93,7 @@ func (f *Farmer) apply(args ...string) error {
 	if err := f.runErr("terraform", args...); err != nil {
 		return err
 	}
-	f.Refresh()
+	f.refresh()
 	return nil
 }
 

--- a/tools/terrafarm/ssh.go
+++ b/tools/terrafarm/ssh.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 )
 
+const sshUser = "ubuntu"
+
 func (f *Farmer) defaultKeyFile() string {
 	base := "."
 	me, err := user.Current()
@@ -31,9 +33,21 @@ func (f *Farmer) defaultKeyFile() string {
 	return filepath.Join(base, ".ssh/"+f.KeyName+".pem")
 }
 
-func (f *Farmer) ssh(user, host, keyfile, cmd string) (stdout string, stderr string, _ error) {
+func (f *Farmer) ssh(host, keyfile, cmd string) (stdout string, stderr string, _ error) {
 	return f.run("ssh",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
-		"-q", "-i", keyfile, user+"@"+host, cmd)
+		"-q", "-i", keyfile, sshUser+"@"+host, cmd)
+}
+
+func (f *Farmer) scp(host, keyfile, src, dest string) error {
+	_, _, err := f.run("scp", "-r",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-q", "-i", keyfile,
+		sshUser+"@"+host+":"+src, dest)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
`go test -v ./tools/terrafarm -key-name=<YOURKEY> -run FiveNodesAndWriters`

logs are stored in a temporary location by default,
but note the `-l` flag. Currently grabs the `logs`
directory from all nodes.