### PR TITLE
Add circle support.

### DIFF
--- a/build/install_deps.sh
+++ b/build/install_deps.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eux
+
+# install the test supervisor, used for the terraform tests.
+pushd tools/supervisor/
+go get github.com/kolo/xmlrpc
+GOBIN=~/bin go install
+popd
+
+go get github.com/tebeka/go2xunit
+
+# if you update the version of terraform here, you should update the
+# cache_directories entry to match in circle.yml.
+TERRAFORM_VERSION="terraform_0.6.16_linux_amd64"
+if [[ ! -e ${TERRAFORM_VERSION} ]]; then
+    wget -q "https://releases.hashicorp.com/terraform/0.6.16/${TERRAFORM_VERSION}.zip"
+    unzip -q -d "${TERRAFORM_VERSION}" "${TERRAFORM_VERSION}.zip"
+fi
+ln -sf "$(pwd -P)/${TERRAFORM_VERSION}/terraform" ~/bin/terraform
+
+cd
+rm -rf         "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach"
+mkdir -p       "${GOPATH%%:*}/src/github.com/cockroachdb/"
+git clone --depth 1 -q "http://github.com/cockroachdb/cockroach" "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach"
+ln -s          "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach" ~/cockroach
+
+cd cockroach
+go get github.com/robfig/glock
+glock sync -n < GLOCKFILE
+
+# make a keypair for gce
+ssh-keygen -f ~/.ssh/google_compute_engine -N ""

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+dependencies:
+  override:
+    - ./build/install_deps.sh
+  cache_directories:
+    - terraform_0.6.16_linux_amd64
+
+test:
+  override:
+    - >
+      if [ -n "${RUN_NIGHTLY_BUILD}" ]; then
+        ./scripts/run_circletest.sh;
+      fi

--- a/scripts/run_circletest.sh
+++ b/scripts/run_circletest.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source $(dirname $0)/utils.sh
+
+BUCKET_NAME="cockroach"
+LATEST_SUFFIX=".LATEST"
+
+$(download_binary "cockroach/acceptance.test")
+
+LOGS_DIR="${CIRCLE_ARTIFACTS}"
+
+./acceptance.test -test.v -test.run FiveNodesAndWriter -test.timeout 24h -remote -nodes 1 -d 1m -key-name google_compute_engine -l $LOGS_DIR -cwd "${HOME}/cockroach/cloud/gce" > >(tee "${LOGS_DIR}/test.stdout.txt") 2> >(tee "${LOGS_DIR}/test.stderr.txt" >&2)
+# trick go2xunit - go test binaries won't print the package summary for some reason
+echo 'ok github.com/cockroachdb/cockroach/acceptance 10.000s' >> "${LOGS_DIR}/test.stdout.txt"
+mkdir -p ${CIRCLE_TEST_REPORTS}/acceptance
+go2xunit < "${LOGS_DIR}/test.stdout.txt" > "${CIRCLE_TEST_REPORTS}/acceptance/acceptance.xml"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -34,6 +34,29 @@ latest_sha() {
   echo ${sha}
 }
 
+# download_binary takes a [repo]/[binary] and an optional sha and downloads
+# the specified binary. If the sha is missing the latest binary will be fetched.
+download_binary() {
+    binary_path="$1"
+    if [ -z "${binary_path}" ]; then
+      echo "binary not specified, run with: [repo-name]/[binary-name]"
+      exit 1
+    fi
+    sha="$2"
+    if [ -z "${sha}" ]; then
+        sha=$(latest_sha "${binary_path}")
+    fi
+
+    # Fetch binary.
+    binary_url="https://s3.amazonaws.com/${BUCKET_NAME}/${binary_path}.${sha}"
+    curl -O ${binary_url}
+
+    # Chmod and symlink.
+    binary_name=$(basename ${binary_path})
+    chmod 755 ${binary_name}.${sha}
+    ln -s -f ${binary_name}.${sha} ${binary_name}
+}
+
 # binary_sha_link takes a binary path and a sha and prints
 # the html link to the commit log on github.
 # eg: binary_sha_link cockroach/sql.test c7c582a6abfbe7ce3c1d23597d928bc8b6f370f6

--- a/test-scheduler/README.md
+++ b/test-scheduler/README.md
@@ -1,0 +1,8 @@
+This is a simple Google App Engine project that exists to trigger daily tests
+on CircleCI.
+
+Deploy it by running the ./deploy.sh script in this directory. You'll need to
+have the Google App Engine SDK for Go installed
+(`brew install app-engine-go-64`) and a valid CircleCI API key exported to the
+environment variable `CIRCLE_CI_TOKEN`. You can get a CircleCI API key
+[here](https://circleci.com/account/api).

--- a/test-scheduler/app.yaml
+++ b/test-scheduler/app.yaml
@@ -1,0 +1,12 @@
+runtime: go
+api_version: go1
+application: cockroach-shared
+
+handlers:
+- url: /.*
+  script: _go_app
+  # this prevents anyone from using the app except for our cron instance
+  login: admin
+
+env_variables:
+    CIRCLE_CI_TOKEN: SET_YOUR_CIRCLE_CI_TOKEN_HERE

--- a/test-scheduler/cron.yaml
+++ b/test-scheduler/cron.yaml
@@ -1,0 +1,5 @@
+cron:
+- description: trigger nightly tests
+  url: /trigger
+  schedule: every day 00:00
+  timezone: America/New_York

--- a/test-scheduler/deploy.sh
+++ b/test-scheduler/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script deploys the build triggering app to GAE.
+
+set -x
+
+which appcfg.py > /dev/null
+if [ $? -ne 0 ]; then
+  echo "Could not find appfcg.py in your path. Install the google app engine sdk."
+  exit 1
+fi
+
+if [ -z "${CIRCLE_CI_TOKEN}" ]; then
+    echo "You must set CIRCLE_CI_TOKEN to your circle ci token to deploy."
+    exit 1
+fi
+
+appcfg.py update -V v1 . -E CIRCLE_CI_TOKEN:${CIRCLE_CI_TOKEN}
+

--- a/test-scheduler/server.go
+++ b/test-scheduler/server.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/log"
+	"google.golang.org/appengine/urlfetch"
+)
+
+func init() {
+	http.HandleFunc("/trigger", triggerHandler)
+}
+
+func getToken() string {
+	return os.Getenv("CIRCLE_CI_TOKEN")
+}
+
+func triggerHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+	client := urlfetch.Client(ctx)
+	token := getToken()
+	log.Debugf(ctx, "https://circleci.com/api/v1/project/cockroachdb/cockroach-prod/tree/master?circle-token="+token)
+	resp, err := client.Post("https://circleci.com/api/v1/project/cockroachdb/cockroach-prod/tree/master?circle-token="+token,
+		"application/json", strings.NewReader("{\"build_parameters\": {\"RUN_NIGHTLY_BUILD\": \"true\"}}"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprint(w, "HTTP POST to CircleCI returned status %v", resp.Status)
+}


### PR DESCRIPTION
This PR adds Circle CI configuration for this repo that runs the latest build of the remote cluster test using Terraform on Google App Engine. It also adds a new GAE app that triggers a build of this test every night at midnight EST.

The tests will not run unless RUN_NIGHTLY_BUILD is set in the build parameters, so normal pushes of cockroach-prod won't cause long tests to run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach-prod/90)
<!-- Reviewable:end -->
