### PR TITLE
Run acceptance for 1 hour, not 1 minute.

### DIFF
--- a/scripts/run_circletest.sh
+++ b/scripts/run_circletest.sh
@@ -11,7 +11,8 @@ $(download_binary "cockroach/acceptance.test")
 
 LOGS_DIR="${CIRCLE_ARTIFACTS}"
 
-./acceptance.test -test.v -test.run FiveNodesAndWriter -test.timeout 24h -remote -nodes 1 -d 1m -key-name google_compute_engine -l $LOGS_DIR -cwd "${HOME}/cockroach/cloud/gce" > >(tee "${LOGS_DIR}/test.stdout.txt") 2> >(tee "${LOGS_DIR}/test.stderr.txt" >&2)
+./acceptance.test -test.v -test.run FiveNodesAndWriter -test.timeout 24h -remote -nodes 1 -d 1h -key-name google_compute_engine -l $LOGS_DIR -cwd "${HOME}/cockroach/cloud/gce" > >(tee "${LOGS_DIR}/test.stdout.txt") 2> "${LOGS_DIR}/test.stderr.txt"
+
 # trick go2xunit - go test binaries won't print the package summary for some reason
 echo 'ok github.com/cockroachdb/cockroach/acceptance 10.000s' >> "${LOGS_DIR}/test.stdout.txt"
 mkdir -p ${CIRCLE_TEST_REPORTS}/acceptance


### PR DESCRIPTION
Previously we were running for 1 minute to test the CircleCI setup. Now we should be running for 1 hour as normal.

Also don't bother watching stderr on the console - it's noisy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach-prod/91)
<!-- Reviewable:end -->
