### PR TITLE
Add logic tests to circle; run in parallel with cluster test

### DIFF
--- a/build/install_deps.sh
+++ b/build/install_deps.sh
@@ -4,7 +4,7 @@ set -eux
 # install the test supervisor, used for the terraform tests.
 pushd tools/supervisor/
 go get github.com/kolo/xmlrpc
-GOBIN=~/bin go install
+go install
 popd
 
 go get github.com/tebeka/go2xunit
@@ -18,15 +18,28 @@ if [[ ! -e ${TERRAFORM_VERSION} ]]; then
 fi
 ln -sf "$(pwd -P)/${TERRAFORM_VERSION}/terraform" ~/bin/terraform
 
+COCKROACH_PATH="${GOPATH%%:*}/src/github.com/cockroachdb/cockroach"
+if [ ! -e "${COCKROACH_PATH}" ]; then
+    git clone --depth 1 -q "https://github.com/cockroachdb/cockroach" "${COCKROACH_PATH}"
+else
+    cd "${COCKROACH_PATH}"
+    git fetch && git reset --hard origin/master
+fi
+
 cd
-rm -rf         "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach"
-mkdir -p       "${GOPATH%%:*}/src/github.com/cockroachdb/"
-git clone --depth 1 -q "http://github.com/cockroachdb/cockroach" "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach"
-ln -s          "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach" ~/cockroach
+ln -s "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach" ~/cockroach
 
 cd cockroach
 go get github.com/robfig/glock
 glock sync -n < GLOCKFILE
+
+SQLLOGICTEST_PATH="${GOPATH%%:*}/src/github.com/cockroachdb/sqllogictest"
+if [ ! -e ${SQLLOGICTEST_PATH} ]; then
+    git clone --depth 1 -q "https://github.com/cockroachdb/sqllogictest" ${SQLLOGICTEST_PATH}
+else
+    cd ${SQLLOGICTEST_PATH}
+    git fetch && git reset --hard origin/master
+fi
 
 # make a keypair for gce
 ssh-keygen -f ~/.ssh/google_compute_engine -N ""

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,15 @@
+checkout:
+  post:
+    - git fetch --unshallow || true
+    - git fetch --tags
+    # GOPATH is cached, so we need to clean out the version from the previous
+    # run or the subsequent `mv` will fail. We put our checkout in the correct
+    # location for the OSX build step.
+    - rm -rf              "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach-prod"
+    - mkdir -p            "${GOPATH%%:*}/src/github.com/cockroachdb/"
+    - mv ~/cockroach-prod "${GOPATH%%:*}/src/github.com/cockroachdb/"
+    - ln -s               "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach-prod" ~/cockroach-prod
+
 dependencies:
   override:
     - ./build/install_deps.sh

--- a/scripts/run_circletest.sh
+++ b/scripts/run_circletest.sh
@@ -1,19 +1,10 @@
 #!/usr/bin/env bash
 
-set -ex
+set -eux
 
-source $(dirname $0)/utils.sh
+cd "$(dirname "$0")"
 
-BUCKET_NAME="cockroach"
-LATEST_SUFFIX=".LATEST"
-
-$(download_binary "cockroach/acceptance.test")
-
-LOGS_DIR="${CIRCLE_ARTIFACTS}"
-
-./acceptance.test -test.v -test.run FiveNodesAndWriter -test.timeout 24h -remote -nodes 1 -d 1h -key-name google_compute_engine -l $LOGS_DIR -cwd "${HOME}/cockroach/cloud/gce" > >(tee "${LOGS_DIR}/test.stdout.txt") 2> >(tee "${LOGS_DIR}/test.stderr.txt" >&2)
-
-# trick go2xunit - go test binaries won't print the package summary for some reason
-echo 'ok github.com/cockroachdb/cockroach/acceptance 10.000s' >> "${LOGS_DIR}/test.stdout.txt"
-mkdir -p ${CIRCLE_TEST_REPORTS}/acceptance
-go2xunit < "${LOGS_DIR}/test.stdout.txt" > "${CIRCLE_TEST_REPORTS}/acceptance/acceptance.xml"
+cat <<'EOF' | parallel -j0 --linebuffer --verbose
+./run_clustertest.sh
+./run_logictests.sh
+EOF

--- a/scripts/run_clustertest.sh
+++ b/scripts/run_clustertest.sh
@@ -1,74 +1,17 @@
-#!/bin/bash
-#
-# A thin wrapper around the `terrafarm` test runner.
-# Requirements for this to work:
-# * working Go environment: GOPATH (but possibly HOME, PATH, GOPATH, GOROOT)
-# * GCE credentials as described in cockroach/cloud/gce/README.md
-# * terraform installed in your PATH
-# * for mailing the results to work: Linux.
-#
-# A sample crontab (to be filled-in) to run this nightly would be:
-# MAILTO=myaddress@myprovider.com
-# KEY_NAME=cockroach-craig
-# HOME=/home/MYUSER
-# PATH=/bin:/sbin:/usr/bin:/usr/bin:/usr/local/bin:/usr/local/sbin:/home/MYUSER/bin:/home/MYUSER/go/bin
-# GOPATH=/home/MYUSER/cockroach
-#
-# 0 0 * * * /home/MYUSER/cockroach/src/github.com/cockroachdb/cockroach-prod/scripts/run_clustertest.sh
+#!/usr/bin/env bash
 
 set -eux
 
-LOGS_DIR="${1-$(mktemp -d)}"
-KEY_NAME="${KEY_NAME-google_compute_engine}"
-MAILTO="${MAILTO-}"
-run_timestamp=$(date  +"%Y-%m-%d-%H:%M:%S")
+source $(dirname $0)/utils.sh
 
+download_binary "cockroach/acceptance.test"
+
+LOGS_DIR="${CIRCLE_ARTIFACTS}/acceptance"
 mkdir -p "${LOGS_DIR}"
 
-# Takes a log directory prefix (in the local directory) and log file name,
-# creates trimmed versions and outputs the attach args to stdout.
-function collate_logs() {
-  prefix=$1
-  name=$2
-  a=""
-  for i in ${prefix}*; do
-    if [ -s "${i}/${name}.stderr" ]; then
-      tail -n 10000 ${i}/${name}.stderr > ${i}.stderr
-      a="${a} -A ${i}.stderr"
-    fi
-    if [ -s "${i}/${name}.stdout" ]; then
-      tail -n 10000 ${i}/${name}.stdout > ${i}.stdout
-      a="${a} -A ${i}.stdout"
-    fi
-  done
-  echo ${a}
-}
+./acceptance.test -test.v -test.run FiveNodesAndWriter -test.timeout 24h -remote -nodes 1 -d 1h -key-name google_compute_engine -l "${LOGS_DIR}" -cwd "${HOME}/cockroach/cloud/gce" > >(tee "${LOGS_DIR}/test.stdout.txt") 2> "${LOGS_DIR}/test.stderr.txt"
 
-function finish() {
-  [[ $? -eq 0 ]] && status="PASSED" || status="FAILED"
-  set +e
-  echo "Job status: ${status}"
-
-  cd "${LOGS_DIR}"
-  pwd
-
-  if [ -z "${MAILTO}" ]; then
-    echo "MAILTO variable not set, not sending email."
-    return
-  fi
-
-  # Generate message and attach logs for each instance.
-  node_args=$(collate_logs node cockroach)
-  writer_args=$(collate_logs writer block_writer)
-
-  cat test.stdout.txt test.stderr.txt |
-  mail --content-type=text/plain ${node_args} ${writer_args} \
-    -s "Cluster test ${status} ${run_timestamp}" "${MAILTO}"
-}
-
-trap finish EXIT
-
-go test -v -tags acceptance -timeout 24h -run FiveNodesAndWriters \
-  github.com/cockroachdb/cockroach/acceptance \
-  -remote -nodes 1 -d 1h -key-name "${KEY_NAME}" -l "${LOGS_DIR}" -cwd "../cloud/gce" \
-  > "${LOGS_DIR}/test.stdout.txt" 2> "${LOGS_DIR}/test.stderr.txt"
+# trick go2xunit - go test binaries won't print the package summary for some reason
+echo 'ok github.com/cockroachdb/cockroach/acceptance 10.000s' >> "${LOGS_DIR}/test.stdout.txt"
+mkdir -p ${CIRCLE_TEST_REPORTS}/acceptance
+go2xunit < "${LOGS_DIR}/test.stdout.txt" > "${CIRCLE_TEST_REPORTS}/acceptance/acceptance.xml"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -80,3 +80,25 @@ binary_sha_link() {
   fi
   echo "Binary: ${binary_path} sha: https://github.com/cockroachdb/${repo}/commits/${sha}"
 }
+
+# create_junit_single_output takes a suite name, a test name, a time in
+# `date +%s.%N` format, a success boolean and a path, and outputs a junit
+# compatible xml file to the path with the input data.
+create_junit_single_output() {
+    suite_name="$1"
+    test_name="$2"
+    time="$3"
+    success="$4"
+    path="$5"
+    failures=0
+    if [ ! "${success}" ]; then
+        failures=1
+    fi
+    echo "<testsuite name=\"${suite_name}\" tests=\"1\" errors=\"0\" failures=\"${failures}\" skip=\"0\">" >> ${path}
+    echo "  <testcase classname=\"${suite_name}\" name=\"${test_name}\" time=\"${time}\">" >> ${path}
+    if [ ! "${success}" ]; then
+        echo "    <failure type=\"Fail\">Test failed</failure>" >> ${path}
+    fi
+    echo "  </testcase>" >> ${path}
+    echo "</testsuite>" >> ${path}
+}


### PR DESCRIPTION
This commit adds the sql logic tests to the nightly circle ci run. They are now run in parallel with the cluster test. Artifacts for both tests are saved in Circle.

Example CircleCI output lives here: https://circleci.com/gh/jordanlewis/cockroach-prod/48

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach-prod/92)
<!-- Reviewable:end -->
