### PR TITLE
Allow acceptance test to log stderr to console to fix CircleCI timeouts

### DIFF
--- a/scripts/run_circletest.sh
+++ b/scripts/run_circletest.sh
@@ -11,7 +11,7 @@ $(download_binary "cockroach/acceptance.test")
 
 LOGS_DIR="${CIRCLE_ARTIFACTS}"
 
-./acceptance.test -test.v -test.run FiveNodesAndWriter -test.timeout 24h -remote -nodes 1 -d 1h -key-name google_compute_engine -l $LOGS_DIR -cwd "${HOME}/cockroach/cloud/gce" > >(tee "${LOGS_DIR}/test.stdout.txt") 2> "${LOGS_DIR}/test.stderr.txt"
+./acceptance.test -test.v -test.run FiveNodesAndWriter -test.timeout 24h -remote -nodes 1 -d 1h -key-name google_compute_engine -l $LOGS_DIR -cwd "${HOME}/cockroach/cloud/gce" > >(tee "${LOGS_DIR}/test.stdout.txt") 2> >(tee "${LOGS_DIR}/test.stderr.txt" >&2)
 
 # trick go2xunit - go test binaries won't print the package summary for some reason
 echo 'ok github.com/cockroachdb/cockroach/acceptance 10.000s' >> "${LOGS_DIR}/test.stdout.txt"


### PR DESCRIPTION
If we don't print during the acceptance test, circle ci will get fed up when we don't write any output for longer than 10 minutes. So we'll just print stderr to the console to get around this issue for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach-prod/93)
<!-- Reviewable:end -->
