### PR TITLE
Fix utils.sh for usage with `set -u`

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -20,7 +20,7 @@ do_retry() {
 BUCKET_NAME="cockroach"
 LATEST_SUFFIX=".LATEST"
 latest_sha() {
-  binary_path="$1"
+  binary_path="${1:-}"
   if [ -z "${binary_path}" ]; then
     echo "binary not specified, run with: [repo-name]/[binary-name]"
     exit 1
@@ -37,12 +37,12 @@ latest_sha() {
 # download_binary takes a [repo]/[binary] and an optional sha and downloads
 # the specified binary. If the sha is missing the latest binary will be fetched.
 download_binary() {
-    binary_path="$1"
+    binary_path="${1:-}"
     if [ -z "${binary_path}" ]; then
       echo "binary not specified, run with: [repo-name]/[binary-name]"
       exit 1
     fi
-    sha="$2"
+    sha="${2:-}"
     if [ -z "${sha}" ]; then
         sha=$(latest_sha "${binary_path}")
     fi
@@ -63,8 +63,8 @@ download_binary() {
 #  Binary: cockroach/sql.test sha:
 #  https://github.com/cockroachdb/cockroach/commits/c7c582a6abfbe7ce3c1d23597d928bc8b6f370f6
 binary_sha_link() {
-  binary_path="$1"
-  sha="$2"
+  binary_path="${1:-}"
+  sha="${2:-}"
   if [ -z "${binary_path}" ]; then
     echo "binary not specified, run with: [repo-name]/[binary-name] [sha]"
     exit 1


### PR DESCRIPTION
Since other scripts call us with `set -u` now, we need to make sure that every variable we reference is defined. For functions, this means not blindly using $1 and $2 when we expect they might be missing - we must use ${1:-} instead which gives a default value of "" if there is no passed in first positional parameter.

This resolves an issue with the nightly tests failing due to running with `set -u`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach-prod/94)
<!-- Reviewable:end -->
