### PR TITLE
Cluster test still needs to print its stderr.

### DIFF
--- a/scripts/run_clustertest.sh
+++ b/scripts/run_clustertest.sh
@@ -9,7 +9,7 @@ download_binary "cockroach/acceptance.test"
 LOGS_DIR="${CIRCLE_ARTIFACTS}/acceptance"
 mkdir -p "${LOGS_DIR}"
 
-./acceptance.test -test.v -test.run FiveNodesAndWriter -test.timeout 24h -remote -nodes 1 -d 1h -key-name google_compute_engine -l "${LOGS_DIR}" -cwd "${HOME}/cockroach/cloud/gce" > >(tee "${LOGS_DIR}/test.stdout.txt") 2> "${LOGS_DIR}/test.stderr.txt"
+./acceptance.test -test.v -test.run FiveNodesAndWriter -test.timeout 24h -remote -nodes 1 -d 1h -key-name google_compute_engine -l "${LOGS_DIR}" -cwd "${HOME}/cockroach/cloud/gce" > >(tee "${LOGS_DIR}/test.stdout.txt") 2> >(tee "${LOGS_DIR}/test.stderr.txt" >&2)
 
 # trick go2xunit - go test binaries won't print the package summary for some reason
 echo 'ok github.com/cockroachdb/cockroach/acceptance 10.000s' >> "${LOGS_DIR}/test.stdout.txt"

--- a/scripts/run_logictests.sh
+++ b/scripts/run_logictests.sh
@@ -20,7 +20,6 @@
 # a limit on the number of retries. This may cause issues.
 #
 # A sample crontab (to be filled-in) to run this nightly would be:
-# MAILTO=myaddress@myprovider.com
 # USER=MYUSER
 # HOME=/home/MYUSER
 # PATH=/bin:/sbin:/usr/bin:/usr/bin:/usr/local/bin:/usr/local/sbin:/home/MYUSER/bin:/home/MYUSER/go/bin
@@ -34,7 +33,6 @@ source $(dirname $0)/utils.sh
 
 COCKROACH_BASE="${GOPATH%%:*}/src/github.com/cockroachdb"
 LOGS_DIR="${CIRCLE_ARTIFACTS}/logictests"
-MAILTO="${MAILTO-}"
 KEY_NAME="${KEY_NAME-google_compute_engine}"
 
 mkdir -p "${LOGS_DIR}"


### PR DESCRIPTION
CircleCI falls asleep if no one writes to the log. Since we run the
cluster test for an hour, we need to make sure that it keeps writing
stuff by printing stderr like we did before the logic tests.

Also remove some unused variables from the logic test runner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach-prod/95)
<!-- Reviewable:end -->
