### PR TITLE
Trim GOPATH in stress tests

### DIFF
--- a/scripts/run_stress.sh
+++ b/scripts/run_stress.sh
@@ -32,7 +32,7 @@ set -x
 
 source $(dirname $0)/utils.sh
 
-COCKROACH_BASE="${GOPATH}/src/github.com/cockroachdb"
+COCKROACH_BASE="${GOPATH%%:*}/src/github.com/cockroachdb"
 LOGS_DIR="${CIRCLE_ARTIFACTS}/stress"
 MAILTO="${MAILTO-}"
 KEY_NAME="${KEY_NAME-google_compute_engine}"


### PR DESCRIPTION
Previously, we were using the raw GOPATH in the script that runs stress
tests. This breaks on machines that have colon-delimited GOPATHs like
on CircleCI.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach-prod/97)
<!-- Reviewable:end -->
