### PR TITLE
acceptance: exit non-zero from scripts on failure

### DIFF
--- a/scripts/run_logictests.sh
+++ b/scripts/run_logictests.sh
@@ -108,3 +108,7 @@ if [ $? -ne 0 ]; then
   echo "Terraform destroy failed."
   exit 1
 fi
+
+if [ ${status} -ne "1" ]; then
+    exit 1
+fi

--- a/scripts/run_stress.sh
+++ b/scripts/run_stress.sh
@@ -129,7 +129,7 @@ for i in ${instances}; do
   for test in $(find cockroach -type f -name '*.stdout' | sed 's/.stdout$//' | sort); do
     result=$(tail -n 1 "${test}.stdout")
     if [ "${result}" != "SUCCESS" ]; then
-      status="FAILED"
+      email_status="FAILED"
       result="FAILED"
       flat_name=$(echo ${test} | tr '/' '_')
       stdoutresponse="no ${test}.stdout file generated"
@@ -184,5 +184,11 @@ done
 if [ -z "${MAILTO}" ]; then
   echo "MAILTO variable not set, not sending email."
 else
-  cat summary.txt summary_success.txt | mail ${attach_args} -s "Stress tests ${status} ${run_timestamp}" ${MAILTO}
+  cat summary.txt summary_success.txt | mail ${attach_args} -s "Stress tests ${email_status} ${run_timestamp}" ${MAILTO}
+fi
+
+if [ $status -eq 0 ]; then
+    # The test failed. Exit with a non-zero return code so the caller knows we
+    # failed.
+    exit 1
 fi


### PR DESCRIPTION
Previously, the terraform test scripts in this repo wouldn't necessarily
return a non-zero exit code if the tests they governed failed. This
prevents TeamCity from realizing that the tests failed when they did.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach-prod/100)
<!-- Reviewable:end -->
